### PR TITLE
Fix base 0.12.1 dockerfile to check out cub submodule correctly

### DIFF
--- a/docker/0.12.1/base/Dockerfile.gpu
+++ b/docker/0.12.1/base/Dockerfile.gpu
@@ -26,7 +26,7 @@ RUN cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib
 # https://github.com/apache/incubator-mxnet/blob/master/docker/Dockerfiles/Dockerfile.in.lib.gpu
 RUN cd /tmp && \
     git clone --recursive https://github.com/apache/incubator-mxnet mxnet && cd mxnet && \
-    git checkout tags/0.12.1 -b 0.12.1 && git submodule update --recursive && \
+    git checkout tags/0.12.1 -b 0.12.1 && git submodule update --init --recursive && \
     make -j$(nproc) USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 USE_DIST_KVSTORE=1 && \
     cd /tmp/mxnet/python && \
     python2 setup.py install && \


### PR DESCRIPTION
This fixes the build error for the 0.12.1 GPU images where the cub files can't be found.

Was able to build the 0.12.1 GPU base images successfully locally with this change.