### PR TITLE
Fix gunicorn python version for 1.0.0 gpu

### DIFF
--- a/docker/1.0.0/base/Dockerfile.gpu
+++ b/docker/1.0.0/base/Dockerfile.gpu
@@ -10,14 +10,6 @@ RUN cd /tmp && \
     python2 get-pip.py && \
     python3 get-pip.py
 
-RUN pip2 install --no-cache \
-    numpy==1.13.3 requests==2.18.4 graphviz==0.8.1 boto3==1.5.2 \
-    six==1.11.0 gevent==1.2.2 gunicorn==19.7.1 flask==0.11 Jinja2==2.9
-
-RUN pip3 install --no-cache \
-    numpy==1.13.3 requests==2.18.4 graphviz==0.8.1 boto3==1.5.2 \
-    six==1.11.0 gevent==1.2.2 gunicorn==19.7.1 flask==0.11 Jinja2==2.9
-
 # build mxnet
 # from https://github.com/apache/incubator-mxnet/blob/master/docker/install/cpp.sh
 RUN cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib

--- a/docker/1.0.0/final/py2/Dockerfile.gpu
+++ b/docker/1.0.0/final/py2/Dockerfile.gpu
@@ -1,7 +1,11 @@
-# Use local version of image built from Dockerfile.cpu in /docker/$version/base directory
+# Use local version of image built from Dockerfile.gpu in /docker/$version/base directory
 FROM mxnet-base:1.0.0-gpu-py2
 ARG mxnet_support_tar=sagemaker_mxnet_container-1.0.tar.gz
 ARG container_support_tar=sagemaker_container_support-1.0.tar.gz
+
+RUN pip2 install --no-cache \
+    numpy==1.13.3 requests==2.18.4 graphviz==0.8.1 boto3==1.5.2 \
+    six==1.11.0 gevent==1.2.2 gunicorn==19.7.1 flask==0.11 Jinja2==2.9
 
 # Will install from pypi once packages are released there. For now, copy from local file system.
 COPY $container_support_tar .

--- a/docker/1.0.0/final/py3/Dockerfile.gpu
+++ b/docker/1.0.0/final/py3/Dockerfile.gpu
@@ -1,7 +1,11 @@
-# Use local version of image built from Dockerfile.cpu in /docker/$version/base directory
+# Use local version of image built from Dockerfile.gpu in /docker/$version/base directory
 FROM mxnet-base:1.0.0-gpu-py3
 ARG mxnet_support_tar=sagemaker_mxnet_container-1.0.tar.gz
 ARG container_support_tar=sagemaker_container_support-1.0.tar.gz
+
+RUN pip3 install --no-cache \
+    numpy==1.13.3 requests==2.18.4 graphviz==0.8.1 boto3==1.5.2 \
+    six==1.11.0 gevent==1.2.2 gunicorn==19.7.1 flask==0.11 Jinja2==2.9
 
 # Will install from pypi once packages are released there. For now, copy from local file system.
 COPY $container_support_tar .


### PR DESCRIPTION
Same change as https://github.com/aws/sagemaker-mxnet-containers/pull/10 for 1.0.0 gpu.