### PR TITLE
Add support for distributed training

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
 
     # We don't declare our dependency on mxnet here because we build with
     # different packages for different variants (e.g. mxnet-mkl and mxnet-cu90).
-    install_requires=['sagemaker-containers==2.1'],
+    install_requires=['sagemaker-containers==2.1', 'retrying==1.3.3'],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock', 'sagemaker',
                  'requests', 'docker-compose']

--- a/src/sagemaker_mxnet_container/distributed.py
+++ b/src/sagemaker_mxnet_container/distributed.py
@@ -32,8 +32,8 @@ class DefaultParameterServer():
         self.ps_port = ps_port
         self.ps_verbose = ps_verbose
 
-    def scheduler_host(self, hosts):
-        return sorted(hosts)[0]
+    def scheduler_host(self):
+        return sorted(self.hosts)[0]
 
     @contextmanager
     def setup(self, current_host):

--- a/src/sagemaker_mxnet_container/distributed.py
+++ b/src/sagemaker_mxnet_container/distributed.py
@@ -27,12 +27,12 @@ class DefaultParameterServer():
     ROLES = ['worker', 'scheduler', 'server']
 
     def __init__(self, hosts, ps_port='8000', ps_verbose='0'):
-        self.scheduler = self.scheduler_host(hosts)
-        self.hosts = hosts
-        self.ps_port = ps_port
         self.ps_verbose = ps_verbose
+        self.ps_port = ps_port
+        self.hosts = hosts
+        self.scheduler = self._scheduler_host()
 
-    def scheduler_host(self):
+    def _scheduler_host(self):
         return sorted(self.hosts)[0]
 
     @contextmanager

--- a/src/sagemaker_mxnet_container/distributed.py
+++ b/src/sagemaker_mxnet_container/distributed.py
@@ -1,0 +1,78 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+from contextlib import contextmanager
+import logging
+import os
+import socket
+import subprocess
+
+from retrying import retry
+
+logger = logging.getLogger(__name__)
+
+
+class DefaultParameterServer():
+    ROLES = ['worker', 'scheduler', 'server']
+
+    def __init__(self, hosts, ps_port='8000', ps_verbose='0'):
+        self.scheduler = self.scheduler_host(hosts)
+        self.hosts = hosts
+        self.ps_port = ps_port
+        self.ps_verbose = ps_verbose
+
+    def scheduler_host(self, hosts):
+        return sorted(hosts)[0]
+
+    @contextmanager
+    def setup(self, current_host):
+        if len(self.hosts) == 1:
+            logger.info('Only one host, so skipping setting up a parameter server')
+        else:
+            self._verify_hosts(self.hosts)
+
+            logger.info('Starting distributed training task')
+            if self.scheduler == current_host:
+                self._run_mxnet_process('scheduler')
+            self._run_mxnet_process('server')
+            os.environ.update(self._env_vars_for_role('worker'))
+
+        yield
+
+    @retry(stop_max_delay=1000 * 60 * 15, wait_exponential_multiplier=100,
+           wait_exponential_max=30000)
+    def _host_lookup(self, host):
+        return socket.gethostbyname(host)
+
+    def _env_vars_for_role(self, role):
+        if role in self.ROLES:
+            return {
+                'DMLC_NUM_WORKER': str(len(self.hosts)),
+                'DMLC_NUM_SERVER': str(len(self.hosts)),
+                'DMLC_ROLE': role,
+                'DMLC_PS_ROOT_URI': self._host_lookup(self.scheduler),
+                'DMLC_PS_ROOT_PORT': self.ps_port,
+                'PS_VERBOSE': self.ps_verbose,
+            }
+
+        raise ValueError('Unexpected role: {}'.format(role))
+
+    def _run_mxnet_process(self, role):
+        role_env = os.environ.copy()
+        role_env.update(self._env_vars_for_role(role))
+        return subprocess.Popen("python -c 'import mxnet'", shell=True, env=role_env).pid
+
+    def _verify_hosts(self, hosts):
+        for host in hosts:
+            self._host_lookup(host)

--- a/src/sagemaker_mxnet_container/training.py
+++ b/src/sagemaker_mxnet_container/training.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 def train(env):
+    logger.info('MXNet training environment: {}'.format(env.to_env_vars()))
     framework.modules.run_module(env.module_dir, env.to_cmd_args(),
                                  env.to_env_vars(), env.module_name)
 

--- a/test/integ/test_mnist_training.py
+++ b/test/integ/test_mnist_training.py
@@ -16,20 +16,33 @@ import os
 
 from sagemaker.mxnet import MXNet
 
+RESOURCE_PATH = os.path.join(os.path.dirname(__file__), '..', 'resources', 'mnist')
+SCRIPT_PATH = os.path.join(RESOURCE_PATH, 'mnist_script_mode.py')
 
-def test_mnist_script_mode(docker_image, sagemaker_local_session):
-    resource_path = os.path.join(os.path.dirname(__file__), '..', 'resources', 'mnist')
-    script_path = os.path.join(resource_path, 'mnist_script_mode.py')
+TRAIN_INPUT = 'file://{}'.format(os.path.join(RESOURCE_PATH, 'train'))
+TEST_INPUT = 'file://{}'.format(os.path.join(RESOURCE_PATH, 'test'))
 
-    mx = MXNet(entry_point=script_path, role='SageMakerRole', train_instance_count=1,
+
+def test_mnist_training(docker_image, sagemaker_local_session):
+    mx = MXNet(entry_point=SCRIPT_PATH, role='SageMakerRole', train_instance_count=1,
                train_instance_type='local', sagemaker_session=sagemaker_local_session,
                image_name=docker_image)
 
-    train = 'file://{}'.format(os.path.join(resource_path, 'train'))
-    test = 'file://{}'.format(os.path.join(resource_path, 'test'))
-    mx.fit({'train': train, 'test': test})
+    _train_and_assert_success(mx)
 
-    output_path = os.path.dirname(mx.create_model().model_data)
+
+def test_distributed_mnist_training(docker_image, sagemaker_local_session):
+    mx = MXNet(entry_point=SCRIPT_PATH, role='SageMakerRole', train_instance_count=2,
+               train_instance_type='local', sagemaker_session=sagemaker_local_session,
+               image_name=docker_image)
+
+    _train_and_assert_success(mx)
+
+
+def _train_and_assert_success(estimator):
+    estimator.fit({'train': TRAIN_INPUT, 'test': TEST_INPUT})
+
+    output_path = os.path.dirname(estimator.create_model().model_data)
     for f in ['output/success', 'model/model-symbol.json', 'model/model-0000.params',
               'model/model-shapes.json']:
         assert os.path.exists(os.path.join(output_path, f)), 'expected file not found: {}'.format(f)

--- a/test/resources/mnist/mnist_script_mode.py
+++ b/test/resources/mnist/mnist_script_mode.py
@@ -126,5 +126,4 @@ if __name__ == '__main__':
     distributed_server = DefaultParameterServer(args.hosts)
     with distributed_server.setup(args.current_host):
         train(args.batch_size, args.epochs, args.learning_rate, num_gpus, args.train, args.test,
-              args.hosts, args.current_host, distributed_server.scheduler_host(),
-              args.model_dir)
+              args.hosts, args.current_host, distributed_server.scheduler, args.model_dir)

--- a/test/resources/mnist/mnist_script_mode.py
+++ b/test/resources/mnist/mnist_script_mode.py
@@ -11,7 +11,6 @@
 #  express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 import argparse
-import ast
 import gzip
 import json
 import logging
@@ -118,14 +117,14 @@ if __name__ == '__main__':
     parser.add_argument('--test', type=str, default=os.environ['SM_CHANNEL_TEST'])
 
     parser.add_argument('--current-host', type=str, default=os.environ['SM_CURRENT_HOST'])
-    parser.add_argument('--hosts', type=str, default=os.environ['SM_HOSTS'])
+    parser.add_argument('--hosts', type=list, default=json.load(os.environ['SM_HOSTS']))
 
     args = parser.parse_args()
 
     num_gpus = int(os.environ['SM_NUM_GPUS'])
-    hosts = ast.literal_eval(args.hosts)
 
-    distributed_server = DefaultParameterServer(hosts)
+    distributed_server = DefaultParameterServer(args.hosts)
     with distributed_server.setup(args.current_host):
         train(args.batch_size, args.epochs, args.learning_rate, num_gpus, args.train, args.test,
-              hosts, args.current_host, distributed_server.scheduler_host(hosts), args.model_dir)
+              args.hosts, args.current_host, distributed_server.scheduler_host(args.hosts),
+              args.model_dir)

--- a/test/resources/mnist/mnist_script_mode.py
+++ b/test/resources/mnist/mnist_script_mode.py
@@ -117,7 +117,7 @@ if __name__ == '__main__':
     parser.add_argument('--test', type=str, default=os.environ['SM_CHANNEL_TEST'])
 
     parser.add_argument('--current-host', type=str, default=os.environ['SM_CURRENT_HOST'])
-    parser.add_argument('--hosts', type=list, default=json.load(os.environ['SM_HOSTS']))
+    parser.add_argument('--hosts', type=list, default=json.loads(os.environ['SM_HOSTS']))
 
     args = parser.parse_args()
 

--- a/test/resources/mnist/mnist_script_mode.py
+++ b/test/resources/mnist/mnist_script_mode.py
@@ -21,7 +21,7 @@ import struct
 import mxnet as mx
 import numpy as np
 
-from sagemaker_mxnet_container.default_parameter_server import DefaultParameterServer
+from sagemaker_mxnet_container.distributed import DefaultParameterServer
 
 
 def load_data(path):

--- a/test/resources/mnist/mnist_script_mode.py
+++ b/test/resources/mnist/mnist_script_mode.py
@@ -126,5 +126,5 @@ if __name__ == '__main__':
     distributed_server = DefaultParameterServer(args.hosts)
     with distributed_server.setup(args.current_host):
         train(args.batch_size, args.epochs, args.learning_rate, num_gpus, args.train, args.test,
-              args.hosts, args.current_host, distributed_server.scheduler_host(args.hosts),
+              args.hosts, args.current_host, distributed_server.scheduler_host(),
               args.model_dir)

--- a/test/unit/test_distributed.py
+++ b/test/unit/test_distributed.py
@@ -18,7 +18,7 @@ from sagemaker_mxnet_container.distributed import DefaultParameterServer
 
 SCHEDULER = 'host-1'
 SINGLE_HOST_LIST = [SCHEDULER]
-MULTIPLE_HOSTS_LIST = [SCHEDULER, 'host-2', 'host-3']
+MULTIPLE_HOSTS_LIST = ['host-2', SCHEDULER, 'host-3']
 
 IP_ADDRESS = '0.0.0.0000'
 DEFAULT_PORT = '8000'
@@ -34,13 +34,24 @@ BASE_ENV_VARS = {
 MXNET_COMMAND = "python -c 'import mxnet'"
 
 
-def test_init():
+def test_init_for_single_host_with_defaults():
     server = DefaultParameterServer(SINGLE_HOST_LIST)
 
     assert server.hosts == SINGLE_HOST_LIST
     assert server.scheduler == SCHEDULER
     assert server.ps_port == DEFAULT_PORT
     assert server.ps_verbose == DEFAULT_VERBOSITY
+
+
+def test_init_for_multiple_hosts_and_ps_options():
+    port = '8080'
+    verbosity = '1'
+    server = DefaultParameterServer(MULTIPLE_HOSTS_LIST, ps_port=port, ps_verbose=verbosity)
+
+    assert server.hosts == MULTIPLE_HOSTS_LIST
+    assert server.scheduler == SCHEDULER
+    assert server.ps_port == port
+    assert server.ps_verbose == verbosity
 
 
 @patch('sagemaker_mxnet_container.distributed.DefaultParameterServer._run_mxnet_process')

--- a/test/unit/test_distributed.py
+++ b/test/unit/test_distributed.py
@@ -54,6 +54,11 @@ def test_init_for_multiple_hosts_and_ps_options():
     assert server.ps_verbose == verbosity
 
 
+def test_scheduler_host():
+    server = DefaultParameterServer(MULTIPLE_HOSTS_LIST)
+    assert server.scheduler_host() == SCHEDULER
+
+
 @patch('sagemaker_mxnet_container.distributed.DefaultParameterServer._run_mxnet_process')
 def test_setup_for_single_host(run_process):
     server = DefaultParameterServer(SINGLE_HOST_LIST)

--- a/test/unit/test_distributed.py
+++ b/test/unit/test_distributed.py
@@ -1,0 +1,95 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+from mock import call, patch
+
+from sagemaker_mxnet_container.distributed import DefaultParameterServer
+
+SCHEDULER = 'host-1'
+SINGLE_HOST_LIST = [SCHEDULER]
+MULTIPLE_HOSTS_LIST = [SCHEDULER, 'host-2', 'host-3']
+
+IP_ADDRESS = '0.0.0.0000'
+DEFAULT_PORT = '8000'
+DEFAULT_VERBOSITY = '0'
+BASE_ENV_VARS = {
+    'DMLC_NUM_WORKER': str(len(MULTIPLE_HOSTS_LIST)),
+    'DMLC_NUM_SERVER': str(len(MULTIPLE_HOSTS_LIST)),
+    'DMLC_PS_ROOT_URI': IP_ADDRESS,
+    'DMLC_PS_ROOT_PORT': DEFAULT_PORT,
+    'PS_VERBOSE': DEFAULT_VERBOSITY,
+}
+
+MXNET_COMMAND = "python -c 'import mxnet'"
+
+
+def test_init():
+    server = DefaultParameterServer(SINGLE_HOST_LIST)
+
+    assert server.hosts == SINGLE_HOST_LIST
+    assert server.scheduler == SCHEDULER
+    assert server.ps_port == DEFAULT_PORT
+    assert server.ps_verbose == DEFAULT_VERBOSITY
+
+
+@patch('sagemaker_mxnet_container.distributed.DefaultParameterServer._run_mxnet_process')
+def test_setup_for_single_host(run_process):
+    server = DefaultParameterServer(SINGLE_HOST_LIST)
+    server.setup(SCHEDULER)
+
+    run_process.assert_not_called()
+
+
+@patch('os.environ', {})
+@patch('subprocess.Popen')
+@patch('sagemaker_mxnet_container.distributed.DefaultParameterServer._host_lookup')
+@patch('sagemaker_mxnet_container.distributed.DefaultParameterServer._verify_hosts')
+def test_setup_for_distributed_scheduler(verify_hosts, host_lookup, popen):
+    host_lookup.return_value = IP_ADDRESS
+
+    server = DefaultParameterServer(MULTIPLE_HOSTS_LIST)
+    with server.setup(SCHEDULER):
+        pass
+
+    verify_hosts.assert_called_with(MULTIPLE_HOSTS_LIST)
+
+    scheduler_env = BASE_ENV_VARS.copy()
+    scheduler_env.update({'DMLC_ROLE': 'scheduler'})
+
+    server_env = BASE_ENV_VARS.copy()
+    server_env.update({'DMLC_ROLE': 'server'})
+
+    calls = [call(MXNET_COMMAND, shell=True, env=scheduler_env),
+             call(MXNET_COMMAND, shell=True, env=server_env)]
+
+    popen.assert_has_calls(calls)
+
+
+@patch('os.environ', {})
+@patch('subprocess.Popen')
+@patch('sagemaker_mxnet_container.distributed.DefaultParameterServer._host_lookup')
+@patch('sagemaker_mxnet_container.distributed.DefaultParameterServer._verify_hosts')
+def test_setup_for_distributed_worker(verify_hosts, host_lookup, popen):
+    host_lookup.return_value = IP_ADDRESS
+
+    server = DefaultParameterServer(MULTIPLE_HOSTS_LIST)
+    with server.setup('host-2'):
+        pass
+
+    verify_hosts.assert_called_with(MULTIPLE_HOSTS_LIST)
+
+    server_env = BASE_ENV_VARS.copy()
+    server_env.update({'DMLC_ROLE': 'server'})
+
+    popen.assert_called_once_with(MXNET_COMMAND, shell=True, env=server_env)

--- a/test/unit/test_distributed.py
+++ b/test/unit/test_distributed.py
@@ -56,7 +56,7 @@ def test_init_for_multiple_hosts_and_ps_options():
 
 def test_scheduler_host():
     server = DefaultParameterServer(MULTIPLE_HOSTS_LIST)
-    assert server.scheduler_host() == SCHEDULER
+    assert server._scheduler_host() == SCHEDULER
 
 
 @patch('sagemaker_mxnet_container.distributed.DefaultParameterServer._run_mxnet_process')


### PR DESCRIPTION
*Description of changes:*
Add a class for users to use to set up a parameter server like before to use with distributed training.

A few note:
* this doesn't work if you have only one host but still want the parameter server. Likely an issue with a process ending before it should, but I'm not sure yet. will investigate further.
* naming is hard. feel free to suggest alternatives :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
