### PR TITLE
Fix serving, update integ tests, and allow user-supplied transform_fn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
 
     # We don't declare our dependency on mxnet here because we build with
     # different packages for different variants (e.g. mxnet-mkl and mxnet-cu90).
-    install_requires=['sagemaker-containers>=2.2.4', 'retrying==1.3.3'],
+    install_requires=['sagemaker-containers>=2.2.5', 'retrying==1.3.3'],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock', 'sagemaker',
                  'requests==2.18.4', 'docker-compose', 'mxnet==1.3.0.post0']

--- a/test/integ/test_hosting.py
+++ b/test/integ/test_hosting.py
@@ -13,24 +13,27 @@
 from __future__ import absolute_import
 
 import json
+import os
 
-import pytest
+from sagemaker.mxnet.model import MXNetModel
 
-import docker_utils
-import utils
+import local_mode
 
 
 # The image should use the model_fn and transform_fn defined
 # in the user-provided script when serving.
-@pytest.mark.skip
-def test_hosting(docker_image, opt_ml, processor):
-    resource_path = 'test/resources/dummy_hosting'
-    utils.copy_resource(resource_path, opt_ml, 'code')
+def test_hosting(docker_image, sagemaker_local_session):
+    resource_path = os.path.join(os.path.dirname(__file__), '..', 'resources', 'dummy_hosting')
+    m = MXNetModel(os.path.join('file://', resource_path, 'code'), 'SageMakerRole',
+                   os.path.join(resource_path, 'code', 'dummy_hosting_module.py'),
+                   image=docker_image, sagemaker_session=sagemaker_local_session)
 
     input = json.dumps({'some': 'json'})
 
-    with docker_utils.HostingContainer(image=docker_image, processor=processor,
-                                       opt_ml=opt_ml, script_name='dummy_hosting_module.py') as c:
-        c.ping()
-        output = c.invoke_endpoint(input)
-        assert input == output
+    with local_mode.lock():
+        try:
+            predictor = m.deploy(1, 'local')
+            output = predictor.predict(input)
+            assert input == output
+        finally:
+            sagemaker_local_session.delete_endpoint(m.endpoint_name)

--- a/test/resources/default_handlers/code/empty_module.py
+++ b/test/resources/default_handlers/code/empty_module.py
@@ -1,14 +1,14 @@
 #  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#  
+#
 #  Licensed under the Apache License, Version 2.0 (the "License").
 #  You may not use this file except in compliance with the License.
 #  A copy of the License is located at
-#  
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-#  
-#  or in the "license" file accompanying this file. This file is distributed 
-#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
-#  express or implied. See the License for the specific language governing 
+#
+#  or in the "license" file accompanying this file. This file is distributed
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#  express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
 # nothing here... we are testing default model loading and handlers

--- a/test/unit/test_serving.py
+++ b/test/unit/test_serving.py
@@ -164,17 +164,17 @@ def test_gluon_transformer_default_predict_fn():
     block.assert_called_with(data)
 
 
-def test_user_module_transformer_with_transform_fn():
+@patch('sagemaker_containers.beta.framework.functions.error_wrapper', lambda x, y: x)
+@patch('sagemaker_mxnet_container.serving.default_model_fn')
+def test_user_module_transformer_with_transform_fn(model_fn):
     class UserModule:
         def __init__(self):
             self.transform_fn = Mock()
 
     user_module = UserModule()
 
-    with pytest.raises(ValueError) as e:
-        _user_module_transformer(user_module, MODEL_DIR)
-
-    assert 'transform_fn is not supported' in str(e)
+    t = _user_module_transformer(user_module, MODEL_DIR)
+    assert t._transform_fn == user_module.transform_fn
 
 
 @patch('sagemaker_containers.beta.framework.functions.error_wrapper', lambda x, y: x)


### PR DESCRIPTION
*Description of changes:*
a few different things happened here:
1. thanks to aws/sagemaker-containers#122, detecting a `transform_fn` in the user module doesn't need to throw an error
1. ^that let me unskip one of the integ tests
1. then I realized I could have unskipped one of the integ tests in my last PR
1. also I found some bugs in my previous serving code, so that's fixed here

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
