### PR TITLE
Set number of model workers for inference server

### DIFF
--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -24,4 +24,4 @@ MODEL_SUCCESS_FILES = [
 ]
 
 # Workaround for the intermittent worker timeout errors
-NUM_MODEL_SERVER_WORKERS = 8
+NUM_MODEL_SERVER_WORKERS = 4

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -24,4 +24,4 @@ MODEL_SUCCESS_FILES = [
 ]
 
 # Workaround for the intermittent worker timeout errors
-NUM_MODEL_SERVER_WORKERS = 1
+NUM_MODEL_SERVER_WORKERS = 2

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -24,4 +24,4 @@ MODEL_SUCCESS_FILES = [
 ]
 
 # Workaround for the intermittent worker timeout errors
-NUM_MODEL_SERVER_WORKERS = 4
+NUM_MODEL_SERVER_WORKERS = 1

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -22,3 +22,6 @@ MODEL_SUCCESS_FILES = [
     os.path.join('model', 'model-shapes.json'),
     os.path.join('model', 'model-0000.params'),
 ]
+
+# Workaround for the intermittent worker timeout errors
+NUM_MODEL_SERVER_WORKERS = 8

--- a/test/integration/local/test_default_model_fn.py
+++ b/test/integration/local/test_default_model_fn.py
@@ -17,7 +17,7 @@ import os
 from sagemaker.mxnet.model import MXNetModel
 
 import local_mode
-from test.integration import RESOURCE_PATH
+from test.integration import NUM_MODEL_SERVER_WORKERS, RESOURCE_PATH
 
 
 # The image should serve a MXNet model saved in the
@@ -26,7 +26,8 @@ def test_default_model_fn(docker_image, sagemaker_local_session, local_instance_
     default_handler_path = os.path.join(RESOURCE_PATH, 'default_handlers')
     m = MXNetModel(os.path.join('file://', default_handler_path, 'model'), 'SageMakerRole',
                    os.path.join(default_handler_path, 'code', 'empty_module.py'),
-                   image=docker_image, sagemaker_session=sagemaker_local_session)
+                   image=docker_image, sagemaker_session=sagemaker_local_session,
+                   model_server_workers=NUM_MODEL_SERVER_WORKERS)
 
     input = [[1, 2]]
 

--- a/test/integration/local/test_gluon_hosting.py
+++ b/test/integration/local/test_gluon_hosting.py
@@ -18,7 +18,7 @@ import os
 from sagemaker.mxnet.model import MXNetModel
 
 import local_mode
-from test.integration import RESOURCE_PATH
+from test.integration import NUM_MODEL_SERVER_WORKERS, RESOURCE_PATH
 
 
 # The image should support serving Gluon-created models.
@@ -26,7 +26,8 @@ def test_gluon_hosting(docker_image, sagemaker_local_session, local_instance_typ
     gluon_path = os.path.join(RESOURCE_PATH, 'gluon_hosting')
     m = MXNetModel(os.path.join('file://', gluon_path, 'model'), 'SageMakerRole',
                    os.path.join(gluon_path, 'code', 'gluon.py'), image=docker_image,
-                   sagemaker_session=sagemaker_local_session)
+                   sagemaker_session=sagemaker_local_session,
+                   model_server_workers=NUM_MODEL_SERVER_WORKERS)
 
     with open(os.path.join(RESOURCE_PATH, 'mnist_images', '04.json'), 'r') as f:
         input = json.load(f)

--- a/test/integration/local/test_hosting.py
+++ b/test/integration/local/test_hosting.py
@@ -18,7 +18,7 @@ import os
 from sagemaker.mxnet.model import MXNetModel
 
 import local_mode
-from test.integration import RESOURCE_PATH
+from test.integration import NUM_MODEL_SERVER_WORKERS, RESOURCE_PATH
 
 
 # The image should use the model_fn and transform_fn defined
@@ -27,7 +27,8 @@ def test_hosting(docker_image, sagemaker_local_session, local_instance_type):
     hosting_resource_path = os.path.join(RESOURCE_PATH, 'dummy_hosting')
     m = MXNetModel(os.path.join('file://', hosting_resource_path, 'code'), 'SageMakerRole',
                    os.path.join(hosting_resource_path, 'code', 'dummy_hosting_module.py'),
-                   image=docker_image, sagemaker_session=sagemaker_local_session)
+                   image=docker_image, sagemaker_session=sagemaker_local_session,
+                   model_server_workers=NUM_MODEL_SERVER_WORKERS)
 
     input = json.dumps({'some': 'json'})
 

--- a/test/integration/local/test_mnist_training.py
+++ b/test/integration/local/test_mnist_training.py
@@ -18,7 +18,7 @@ import numpy
 from sagemaker.mxnet import MXNet
 
 import local_mode
-from test.integration import NUM_MODEL_SERVER_WORKERS, MODEL_SUCCESS_FILES, RESOURCE_PATH
+from test.integration import MODEL_SUCCESS_FILES, NUM_MODEL_SERVER_WORKERS, RESOURCE_PATH
 
 MNIST_PATH = os.path.join(RESOURCE_PATH, 'mnist')
 SCRIPT_PATH = os.path.join(MNIST_PATH, 'mnist.py')

--- a/test/integration/local/test_mnist_training.py
+++ b/test/integration/local/test_mnist_training.py
@@ -18,7 +18,7 @@ import numpy
 from sagemaker.mxnet import MXNet
 
 import local_mode
-from test.integration import MODEL_SUCCESS_FILES, RESOURCE_PATH
+from test.integration import NUM_MODEL_SERVER_WORKERS, MODEL_SUCCESS_FILES, RESOURCE_PATH
 
 MNIST_PATH = os.path.join(RESOURCE_PATH, 'mnist')
 SCRIPT_PATH = os.path.join(MNIST_PATH, 'mnist.py')
@@ -37,7 +37,8 @@ def test_mnist_training_and_serving(docker_image, sagemaker_local_session, local
 
     with local_mode.lock():
         try:
-            predictor = mx.deploy(1, local_instance_type)
+            model = mx.create_model(model_server_workers=NUM_MODEL_SERVER_WORKERS)
+            predictor = model.deploy(1, local_instance_type)
             data = numpy.zeros(shape=(1, 1, 28, 28))
             predictor.predict(data)
         finally:


### PR DESCRIPTION
Not the greatest solution, but this should mitigate the worker timeouts we've seen in only very specific cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
