### PR TITLE
Fix inference for CSV and limit valid content types

### DIFF
--- a/docker/1.3.0/final/Dockerfile.cpu
+++ b/docker/1.3.0/final/Dockerfile.cpu
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-ARG framework_installable
+ARG framework_installable=foo
 ARG py_version
 ARG framework_support_installable=sagemaker_mxnet_container-2.0.0.tar.gz
 
@@ -21,16 +21,17 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     rm get-pip.py
 
 # Will install from pypi once packages are released there. For now, copy from local file system.
-COPY $framework_installable .
+# COPY $framework_installable .
 COPY $framework_support_installable .
 
 RUN framework_installable_local=$(basename $framework_installable) && \
     framework_support_installable_local=$(basename $framework_support_installable) && \
     \
-    pip install $framework_installable_local && \
+    # pip install $framework_installable_local && \
     pip install $framework_support_installable_local && \
+    pip install mxnet==1.3.0.post0 && \
     \
-    rm $framework_installable_local && \
+    # rm $framework_installable_local && \
     rm $framework_support_installable_local
 
 RUN pip install onnx==1.2.1 \

--- a/docker/1.3.0/final/Dockerfile.cpu
+++ b/docker/1.3.0/final/Dockerfile.cpu
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-ARG framework_installable=foo
+ARG framework_installable
 ARG py_version
 ARG framework_support_installable=sagemaker_mxnet_container-2.0.0.tar.gz
 
@@ -21,17 +21,16 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     rm get-pip.py
 
 # Will install from pypi once packages are released there. For now, copy from local file system.
-# COPY $framework_installable .
+COPY $framework_installable .
 COPY $framework_support_installable .
 
 RUN framework_installable_local=$(basename $framework_installable) && \
     framework_support_installable_local=$(basename $framework_support_installable) && \
     \
-    # pip install $framework_installable_local && \
+    pip install $framework_installable_local && \
     pip install $framework_support_installable_local && \
-    pip install mxnet==1.3.0.post0 && \
     \
-    # rm $framework_installable_local && \
+    rm $framework_installable_local && \
     rm $framework_support_installable_local
 
 RUN pip install onnx==1.2.1 \


### PR DESCRIPTION
In retrospect, I've decided blindly opening up the permitted content types was a bad idea.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
