### PR TITLE
Add env variable to make sure default encoding is utf-8

### DIFF
--- a/docker/1.3.0/final/Dockerfile.cpu
+++ b/docker/1.3.0/final/Dockerfile.cpu
@@ -55,7 +55,10 @@ RUN ln -s /dev/null /dev/raw1394
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib"
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib" \
+    PYTHONIOENCODING=UTF-8 \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
 
 ENV SAGEMAKER_TRAINING_MODULE sagemaker_mxnet_container.training:main
 ENV SAGEMAKER_SERVING_MODULE sagemaker_mxnet_container.serving:main

--- a/docker/1.3.0/final/Dockerfile.gpu
+++ b/docker/1.3.0/final/Dockerfile.gpu
@@ -57,7 +57,10 @@ RUN ln -s /dev/null /dev/raw1394
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib"
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib" \
+    PYTHONIOENCODING=UTF-8 \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
 
 ENV SAGEMAKER_TRAINING_MODULE sagemaker_mxnet_container.training:main
 ENV SAGEMAKER_SERVING_MODULE sagemaker_mxnet_container.serving:main


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-containers/issues/159

*Description of changes:*
1. Add LANG to set language as utf-8
2. Add LC_ALL to set the locale to be utf-8
3. Add PYTHONIOENCODING=UTF-8 for python 2  to encode with utf-8 as default.

Reference:
https://docs.python.org/3/using/cmdline.html#envvar-PYTHONIOENCODING
https://unix.stackexchange.com/questions/87745/what-does-lc-all-c-do

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
