### PR TITLE
Freeze pip version to <=18.1

### DIFF
--- a/docker/1.3.0/final/Dockerfile.cpu
+++ b/docker/1.3.0/final/Dockerfile.cpu
@@ -29,7 +29,7 @@ RUN rm /usr/bin/python && ln -s "/usr/bin/python$py_version" /usr/bin/python
 
 # Install pip
 RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
-    /usr/bin/python get-pip.py && \
+    /usr/bin/python get-pip.py 'pip<=18.1' && \
     rm get-pip.py
 
 # Will install from pypi once packages are released there. For now, copy from local file system.

--- a/docker/1.3.0/final/Dockerfile.gpu
+++ b/docker/1.3.0/final/Dockerfile.gpu
@@ -31,7 +31,7 @@ RUN rm /usr/bin/python && ln -s "/usr/bin/python$py_version" /usr/bin/python
 
 # install pip
 RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
-    /usr/bin/python get-pip.py && \
+    /usr/bin/python get-pip.py 'pip<=18.1' && \
     rm get-pip.py
 
 # Will install from pypi once packages are released there. For now, copy from local file system.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Freeze pip version <=18.1 to be consistent with other SageMaker framework containers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
