### PR TITLE
Read framework version from Python SDK for integ test default

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,6 +21,7 @@ import tempfile
 import boto3
 import pytest
 from sagemaker import LocalSession, Session
+from sagemaker.mxnet import MXNet
 
 logger = logging.getLogger(__name__)
 logging.getLogger('boto').setLevel(logging.INFO)
@@ -35,7 +36,7 @@ SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 def pytest_addoption(parser):
     parser.addoption('--docker-base-name', default='preprod-mxnet')
     parser.addoption('--region', default='us-west-2')
-    parser.addoption('--framework-version', default='1.3.0')
+    parser.addoption('--framework-version', default=MXNet.LATEST_VERSION)
     parser.addoption('--py-version', default='3', choices=['2', '3'])
     parser.addoption('--processor', default='cpu', choices=['gpu', 'cpu'])
     parser.addoption('--aws-id', default=None)


### PR DESCRIPTION
Following https://github.com/aws/sagemaker-tensorflow-container/pull/166

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
