### PR TITLE
Fix instance_type fixture setup for tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -84,8 +84,9 @@ def tag(request, framework_version, processor, py_version):
 
 @pytest.fixture(scope='session')
 def instance_type(request, processor):
-    return request.config.getoption('--instance-type') or \
-        'ml.c4.xlarge' if processor == 'cpu' else 'ml.p2.xlarge'
+    provided_instance_type = request.config.getoption('--instance-type')
+    default_instance_type = 'ml.c4.xlarge' if processor == 'cpu' else 'ml.p2.xlarge'
+    return provided_instance_type if provided_instance_type is not None else default_instance_type
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
*Description of changes:*
Seems like pytest's behavior around fixtures isn't quite as expected, so currently the tests will use the default instance type even when it is supplied.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
