### PR TITLE
add elastic inference sagemaker integ test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -315,7 +315,7 @@ The `accelerator-type` is your specified `Amazon Elastic Inference Accelerator <
 
 ::
 
-    # Example for running Elastic Inference functional test
+    # Example for running Elastic Inference SageMaker end to end test
     pytest test/integration/sagemaker/test_elastic_inference.py --aws-id 12345678910 \
                                                                 --docker-base-name preprod-mxnet \
                                                                 --instance-type ml.m4.xlarge \

--- a/README.rst
+++ b/README.rst
@@ -309,6 +309,19 @@ To run SageMaker integration tests:
                                       --instance-type ml.m4.xlarge \
                                       --tag 1.3.0-cpu-py3
 
+If you want to run a SageMaker end to end test for your Elastic Inference container, you will need to provide an `accelerator_type` as an additional pytest argument.
+
+The `accelerator-type` is your specified `Amazon Elastic Inference Accelerator <https://aws.amazon.com/sagemaker/pricing/instance-types/>`__ type that will be attached to your instance type.
+
+::
+
+    # Example for running Elastic Inference functional test
+    pytest test/integration/sagemaker/test_elastic_inference.py --aws-id 12345678910 \
+                                                                --docker-base-name preprod-mxnet \
+                                                                --instance-type ml.m4.xlarge \
+                                                                --accelerator-type ml.eia1.medium \
+                                                                --tag 1.0
+
 Contributing
 ------------
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -41,6 +41,7 @@ def pytest_addoption(parser):
     parser.addoption('--processor', default='cpu', choices=['gpu', 'cpu'])
     parser.addoption('--aws-id', default=None)
     parser.addoption('--instance-type', default=None)
+    parser.addoption('--accelerator-type', default=None)
     # If not specified, will default to {framework-version}-{processor}-py{py-version}
     parser.addoption('--tag', default=None)
 
@@ -87,6 +88,11 @@ def instance_type(request, processor):
     provided_instance_type = request.config.getoption('--instance-type')
     default_instance_type = 'ml.c4.xlarge' if processor == 'cpu' else 'ml.p2.xlarge'
     return provided_instance_type if provided_instance_type is not None else default_instance_type
+
+
+@pytest.fixture(scope='session')
+def accelerator_type(request):
+    return request.config.getoption('--accelerator-type')
 
 
 @pytest.fixture(scope='session')

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -24,3 +24,7 @@ MODEL_SUCCESS_FILES = {
 # Workaround for the intermittent worker timeout errors
 # TODO: find and solve the root cause of this issue
 NUM_MODEL_SERVER_WORKERS = 2
+
+# EI is currently only supported in the following regions
+# regions were derived from https://aws.amazon.com/machine-learning/elastic-inference/pricing/
+EI_SUPPORTED_REGIONS = ['us-east-1', 'us-east-2', 'us-west-2', 'eu-west-1', 'ap-northeast-1', 'ap-northeast-2']

--- a/test/integration/sagemaker/test_elastic_inference.py
+++ b/test/integration/sagemaker/test_elastic_inference.py
@@ -1,0 +1,76 @@
+#  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  or in the "license" file accompanying this file. This file is distributed
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#  express or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+import logging
+import os
+
+import numpy as np
+import pytest
+from sagemaker.mxnet import MXNetModel
+from sagemaker.utils import sagemaker_timestamp
+
+from test.integration import RESOURCE_PATH, EI_SUPPORTED_REGIONS
+from test.integration.sagemaker.timeout import timeout_and_delete_endpoint_by_name
+
+logger = logging.getLogger(__name__)
+logging.getLogger('boto3').setLevel(logging.INFO)
+logging.getLogger('botocore').setLevel(logging.INFO)
+logging.getLogger('factory.py').setLevel(logging.INFO)
+logging.getLogger('auth.py').setLevel(logging.INFO)
+logging.getLogger('connectionpool.py').setLevel(logging.INFO)
+logging.getLogger('session.py').setLevel(logging.DEBUG)
+logging.getLogger('sagemaker').setLevel(logging.DEBUG)
+
+
+@pytest.fixture(autouse=True)
+def skip_if_no_accelerator(accelerator_type):
+    if accelerator_type is None:
+        pytest.skip('Skipping because accelerator type was not provided')
+
+
+@pytest.fixture(autouse=True)
+def skip_if_non_supported_ei_region(region):
+    if region not in EI_SUPPORTED_REGIONS:
+        pytest.skip('EI is not supported in {}'.format(region))
+
+
+@pytest.fixture
+def pretrained_model_data(region):
+    return 's3://sagemaker-sample-data-{}/mxnet/model/resnet/resnet_50.tar.gz'.format(region)
+
+
+@pytest.mark.skip_if_non_supported_ei_region
+@pytest.mark.skip_if_no_accelerator
+def test_deploy_elastic_inference_with_pretrained_model(pretrained_model_data, ecr_image, sagemaker_session,
+                                                        instance_type, accelerator_type):
+    default_handler_path = os.path.join(RESOURCE_PATH, 'default_handlers')
+    endpoint_name = 'test-mxnet-ei-deploy-model-{}'.format(sagemaker_timestamp())
+
+    with timeout_and_delete_endpoint_by_name(endpoint_name=endpoint_name, sagemaker_session=sagemaker_session,
+                                             minutes=20):
+        model = MXNetModel(model_data=pretrained_model_data,
+                           entry_point=os.path.join(default_handler_path, 'code', 'empty_module.py'),
+                           role='SageMakerRole',
+                           image=ecr_image,
+                           sagemaker_session=sagemaker_session)
+
+        logger.info('deploying model to endpoint: {}'.format(endpoint_name))
+        predictor = model.deploy(initial_instance_count=1,
+                                 instance_type=instance_type,
+                                 accelerator_type=accelerator_type,
+                                 endpoint_name=endpoint_name)
+
+        random_input = np.zeros(shape=(1, 3, 224, 224))
+
+        predict_response = predictor.predict(random_input.tolist())
+        assert predict_response['outputs']['probabilities']

--- a/test/integration/sagemaker/test_elastic_inference.py
+++ b/test/integration/sagemaker/test_elastic_inference.py
@@ -20,7 +20,7 @@ from sagemaker.mxnet import MXNetModel
 from sagemaker.utils import sagemaker_timestamp
 
 from test.integration import RESOURCE_PATH, EI_SUPPORTED_REGIONS
-from test.integration.sagemaker.timeout import timeout_and_delete_endpoint_by_name
+from timeout import timeout_and_delete_endpoint_by_name
 
 logger = logging.getLogger(__name__)
 logging.getLogger('boto3').setLevel(logging.INFO)

--- a/test/integration/sagemaker/test_elastic_inference.py
+++ b/test/integration/sagemaker/test_elastic_inference.py
@@ -73,4 +73,4 @@ def test_deploy_elastic_inference_with_pretrained_model(pretrained_model_data, e
         random_input = np.zeros(shape=(1, 3, 224, 224))
 
         predict_response = predictor.predict(random_input.tolist())
-        assert predict_response['outputs']['probabilities']
+        assert predict_response


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added EI integ test

Test results:

**=== non-supported region ===**
pytest -rs test/integration/sagemaker/test_elastic_inference.py --accelerator-type ml.eia1.medium --region ap-southeast-1

test/integration/sagemaker/test_elastic_inference.py::test_deploy_elastic_inference_with_pretrained_model SKIPPED
============================================================================== short test summary info ==============================================================================
SKIP [1] /Users/choidan/workspace/container/sagemaker-mxnet-containers/test/integration/sagemaker/test_elastic_inference.py:45: EI is not supported in ap-southeast-1

**=== no accelerator provided ===**
pytest test/integration/sagemaker/test_elastic_inference.py

test/integration/sagemaker/test_elastic_inference.py::test_deploy_elastic_inference_with_pretrained_model SKIPPED
============================================================================== short test summary info ==============================================================================
/Users/choidan/workspace/container/sagemaker-mxnet-containers/test/integration/sagemaker/test_elastic_inference.py:39: Skipping because accelerator type was not provided

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
