### PR TITLE
Set 'channels first' for Keras

### DIFF
--- a/docker/1.3.0/final/Dockerfile.cpu
+++ b/docker/1.3.0/final/Dockerfile.cpu
@@ -48,6 +48,8 @@ RUN framework_installable_local=$(basename $framework_installable) && \
 RUN pip install onnx==1.2.1 \
                 keras-mxnet==2.2.2
 
+COPY keras.json /root/.keras/keras.json
+
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394
 # TODO: Should we be installing OpenCV in our image like this? Is there another way we can fix this?

--- a/docker/1.3.0/final/Dockerfile.cpu
+++ b/docker/1.3.0/final/Dockerfile.cpu
@@ -48,6 +48,8 @@ RUN framework_installable_local=$(basename $framework_installable) && \
 RUN pip install onnx==1.2.1 \
                 keras-mxnet==2.2.2
 
+# "channels first" is recommended for keras-mxnet
+# https://github.com/awslabs/keras-apache-mxnet/blob/master/docs/mxnet_backend/performance_guide.md#channels-first-image-data-format-for-cnn
 RUN mkdir /root/.keras && \
     echo '{"image_data_format": "channels_first"}' > /root/.keras/keras.json
 

--- a/docker/1.3.0/final/Dockerfile.cpu
+++ b/docker/1.3.0/final/Dockerfile.cpu
@@ -48,7 +48,8 @@ RUN framework_installable_local=$(basename $framework_installable) && \
 RUN pip install onnx==1.2.1 \
                 keras-mxnet==2.2.2
 
-COPY keras.json /root/.keras/keras.json
+RUN mkdir /root/.keras && \
+    echo '{"image_data_format": "channels_first"}' > /root/.keras/keras.json
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394

--- a/docker/1.3.0/final/Dockerfile.gpu
+++ b/docker/1.3.0/final/Dockerfile.gpu
@@ -50,7 +50,8 @@ RUN framework_installable_local=$(basename $framework_installable) && \
 RUN pip install onnx==1.2.1 \
                 keras-mxnet==2.2.2
 
-COPY keras.json /root/.keras/keras.json
+RUN mkdir /root/.keras && \
+    echo '{"image_data_format": "channels_first"}' > /root/.keras/keras.json
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394

--- a/docker/1.3.0/final/Dockerfile.gpu
+++ b/docker/1.3.0/final/Dockerfile.gpu
@@ -50,6 +50,8 @@ RUN framework_installable_local=$(basename $framework_installable) && \
 RUN pip install onnx==1.2.1 \
                 keras-mxnet==2.2.2
 
+COPY keras.json /root/.keras/keras.json
+
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394
 # TODO: Should we be installing OpenCV in our image like this? Is there another way we can fix this?

--- a/docker/1.3.0/final/Dockerfile.gpu
+++ b/docker/1.3.0/final/Dockerfile.gpu
@@ -50,6 +50,8 @@ RUN framework_installable_local=$(basename $framework_installable) && \
 RUN pip install onnx==1.2.1 \
                 keras-mxnet==2.2.2
 
+# "channels first" is recommended for keras-mxnet
+# https://github.com/awslabs/keras-apache-mxnet/blob/master/docs/mxnet_backend/performance_guide.md#channels-first-image-data-format-for-cnn
 RUN mkdir /root/.keras && \
     echo '{"image_data_format": "channels_first"}' > /root/.keras/keras.json
 

--- a/docker/1.3.0/final/keras.json
+++ b/docker/1.3.0/final/keras.json
@@ -1,3 +1,0 @@
-{
-    "image_data_format": "channels_first"
-}

--- a/docker/1.3.0/final/keras.json
+++ b/docker/1.3.0/final/keras.json
@@ -1,0 +1,3 @@
+{
+    "image_data_format": "channels_first"
+}

--- a/test/resources/keras/keras_mnist.py
+++ b/test/resources/keras/keras_mnist.py
@@ -43,9 +43,8 @@ def main(batch_size, epochs, num_classes, training_channel, model_dir):
         x_test = x_test.reshape(x_test.shape[0], 1, img_rows, img_cols)
         input_shape = (1, img_rows, img_cols)
     else:
-        x_train = x_train.reshape(x_train.shape[0], img_rows, img_cols, 1)
-        x_test = x_test.reshape(x_test.shape[0], img_rows, img_cols, 1)
-        input_shape = (img_rows, img_cols, 1)
+        raise ValueError('Unexpected image data format (expected "channels_first"): {}'
+                         .format(K.image_data_format()))
 
     x_train = x_train.astype('float32')
     x_test = x_test.astype('float32')
@@ -90,7 +89,7 @@ def main(batch_size, epochs, num_classes, training_channel, model_dir):
     data_name, data_shapes = keras.models.save_mxnet_model(model=model, prefix=model_prefix,
                                                            epoch=0)
 
-    signature = [{'name': data_name, 'shape': [dim for dim in data_desc.shape]}
+    signature = [{'name': data_name[0], 'shape': [dim for dim in data_desc.shape]}
                  for data_desc in data_shapes]
     with open(os.path.join(model_dir, 'model-shapes.json'), 'w') as f:
         json.dump(signature, f)


### PR DESCRIPTION
*Description of changes:*
Keras defaults to "channels last" likely because that's what TF expects; MXNet, however, requires "channels first."

Because our containers don't touch the training script itself, using a Keras config file seems like the best option. This file should live in `~/.keras/keras.json`, and I wasn't able to find a way to change that path (setting `KERAS_HOME` did not work despite https://stackoverflow.com/a/46506589). When our containers are run without any user specification (as I don't believe they are in SageMaker), `~` points to `/root`.

When future versions of MXNet are added, it will probably make sense to not house `keras.json` in the version-specific Docker folder. Once we've finished updating our build processes, I think it'll be easiest to revise the Dockerfile to assume we're building from the top level directory rather than the image-specific one, which will make it nicer for putting `keras.json` somewhere else. (Personally I'm not a fan of putting `../../keras.json` in our Dockerfile, but I'm open to it.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
