### PR TITLE
add training dockerfile for 1.4.0

### DIFF
--- a/docker/1.4.0/final/Dockerfile.cpu.training
+++ b/docker/1.4.0/final/Dockerfile.cpu.training
@@ -1,0 +1,54 @@
+FROM ubuntu:16.04
+
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    build-essential \
+    libopencv-dev \
+    curl \
+    && add-apt-repository ppa:deadsnakes/ppa -y \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /
+
+ARG py_version
+
+RUN if [ $py_version -eq 3 ]; then PYTHON_VERSION=python3.6; else PYTHON_VERSION=python2.7; fi && \
+        apt-get update && apt-get install -y --no-install-recommends $PYTHON_VERSION-dev --allow-unauthenticated  && \
+        ln -s -f /usr/bin/$PYTHON_VERSION /usr/bin/python && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install pip
+RUN cd /tmp && \
+    curl -O https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py 'pip<=18.1' && rm get-pip.py
+
+RUN pip install --no-cache mxnet-mkl==1.4.0.post0 \
+                           onnx==1.4.1 \
+                           keras-mxnet==2.2.4.1
+
+# TODO: The name for the tar.gz binary may change
+COPY dist/sagemaker_mxnet_container-2.0.0.tar.gz /sagemaker_mxnet_container-2.0.0.tar.gz
+
+RUN pip install --no-cache /sagemaker_mxnet_container-2.0.0.tar.gz && \
+    rm /sagemaker_mxnet_container-2.0.0.tar.gz
+
+# "channels first" is recommended for keras-mxnet
+# https://github.com/awslabs/keras-apache-mxnet/blob/master/docs/mxnet_backend/performance_guide.md#channels-first-image-data-format-for-cnn
+RUN mkdir /root/.keras && \
+    echo '{"image_data_format": "channels_first"}' > /root/.keras/keras.json
+
+# This is here to make our installed version of OpenCV work.
+# https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394
+# TODO: Should we be installing OpenCV in our image like this? Is there another way we can fix this?
+RUN ln -s /dev/null /dev/raw1394
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib" \
+    PYTHONIOENCODING=UTF-8 \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+ENV SAGEMAKER_TRAINING_MODULE sagemaker_mxnet_container.training:main

--- a/docker/1.4.0/final/Dockerfile.cpu.training
+++ b/docker/1.4.0/final/Dockerfile.cpu.training
@@ -1,20 +1,16 @@
+ARG py_version
+
 FROM ubuntu:16.04
 
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    software-properties-common \
-    build-essential \
-    libopencv-dev \
-    curl \
-    && add-apt-repository ppa:deadsnakes/ppa -y \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /
-
-ARG py_version
-
-RUN if [ $py_version -eq 3 ]; then PYTHON_VERSION=python3.6; else PYTHON_VERSION=python2.7; fi && \
+RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libopencv-dev \
+        curl && \
+    if [ $py_version -eq 3 ]; then PYTHON_VERSION=python3.6; else PYTHON_VERSION=python2.7; fi && \
         apt-get update && apt-get install -y --no-install-recommends $PYTHON_VERSION-dev --allow-unauthenticated  && \
         ln -s -f /usr/bin/$PYTHON_VERSION /usr/bin/python && \
     rm -rf /var/lib/apt/lists/*
@@ -24,14 +20,14 @@ RUN cd /tmp && \
     curl -O https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py 'pip<=18.1' && rm get-pip.py
 
-RUN pip install --no-cache mxnet-mkl==1.4.0.post0 \
-                           onnx==1.4.1 \
-                           keras-mxnet==2.2.4.1
+WORKDIR /
 
-# TODO: The name for the tar.gz binary may change
 COPY dist/sagemaker_mxnet_container-2.0.0.tar.gz /sagemaker_mxnet_container-2.0.0.tar.gz
 
-RUN pip install --no-cache /sagemaker_mxnet_container-2.0.0.tar.gz && \
+RUN pip install --no-cache mxnet-mkl==1.4.0.post0 \
+                           keras-mxnet==2.2.4.1 \
+                           onnx==1.4.1 \
+                           /sagemaker_mxnet_container-2.0.0.tar.gz && \
     rm /sagemaker_mxnet_container-2.0.0.tar.gz
 
 # "channels first" is recommended for keras-mxnet

--- a/docker/1.4.0/final/Dockerfile.cpu.training
+++ b/docker/1.4.0/final/Dockerfile.cpu.training
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends software-proper
 # Install pip
 RUN cd /tmp && \
     curl -O https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py 'pip<=18.1' && rm get-pip.py
+    python get-pip.py 'pip==19.1' && rm get-pip.py
 
 WORKDIR /
 

--- a/docker/1.4.0/final/Dockerfile.gpu.training
+++ b/docker/1.4.0/final/Dockerfile.gpu.training
@@ -1,22 +1,17 @@
-# TODO: Update to cuda 10 when SageMaker platform supports it
-FROM nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04
+ARG py_version
+
+FROM nvidia/cuda:9.2-cudnn7-runtime-ubuntu16.04
 
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    software-properties-common \
-    build-essential \
-    libopencv-dev \
-    curl \
-    && add-apt-repository ppa:deadsnakes/ppa -y \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /
-
-ARG py_version
-
-RUN if [ $py_version -eq 3 ]; then PYTHON_VERSION=python3.6; else PYTHON_VERSION=python2.7; fi && \
-        apt-get update && apt-get install -y --no-install-recommends $PYTHON_VERSION-dev --allow-unauthenticated  && \
+RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libopencv-dev \
+        curl && \
+    if [ $py_version -eq 3 ]; then PYTHON_VERSION=python3.6; else PYTHON_VERSION=python2.7; fi && \
+        apt-get update && apt-get install -y --no-install-recommends $PYTHON_VERSION-dev && \
         ln -s -f /usr/bin/$PYTHON_VERSION /usr/bin/python && \
     rm -rf /var/lib/apt/lists/*
 
@@ -25,14 +20,14 @@ RUN cd /tmp && \
     curl -O https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py 'pip<=18.1' && rm get-pip.py
 
-RUN pip install --no-cache mxnet-mkl==1.4.0.post0 \
-                           onnx==1.4.1 \
-                           keras-mxnet==2.2.4.1
+WORKDIR /
 
-# TODO: The name for the tar.gz binary may change
 COPY dist/sagemaker_mxnet_container-2.0.0.tar.gz /sagemaker_mxnet_container-2.0.0.tar.gz
 
-RUN pip install --no-cache /sagemaker_mxnet_container-2.0.0.tar.gz && \
+RUN pip install --no-cache mxnet-cu92mkl==1.4.0.post0 \
+                           keras-mxnet==2.2.4.1 \
+                           onnx==1.4.1 \
+                           /sagemaker_mxnet_container-2.0.0.tar.gz && \
     rm /sagemaker_mxnet_container-2.0.0.tar.gz
 
 # "channels first" is recommended for keras-mxnet

--- a/docker/1.4.0/final/Dockerfile.gpu.training
+++ b/docker/1.4.0/final/Dockerfile.gpu.training
@@ -1,0 +1,55 @@
+# TODO: Update to cuda 10 when SageMaker platform supports it
+FROM nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04
+
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    build-essential \
+    libopencv-dev \
+    curl \
+    && add-apt-repository ppa:deadsnakes/ppa -y \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /
+
+ARG py_version
+
+RUN if [ $py_version -eq 3 ]; then PYTHON_VERSION=python3.6; else PYTHON_VERSION=python2.7; fi && \
+        apt-get update && apt-get install -y --no-install-recommends $PYTHON_VERSION-dev --allow-unauthenticated  && \
+        ln -s -f /usr/bin/$PYTHON_VERSION /usr/bin/python && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install pip
+RUN cd /tmp && \
+    curl -O https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py 'pip<=18.1' && rm get-pip.py
+
+RUN pip install --no-cache mxnet-mkl==1.4.0.post0 \
+                           onnx==1.4.1 \
+                           keras-mxnet==2.2.4.1
+
+# TODO: The name for the tar.gz binary may change
+COPY dist/sagemaker_mxnet_container-2.0.0.tar.gz /sagemaker_mxnet_container-2.0.0.tar.gz
+
+RUN pip install --no-cache /sagemaker_mxnet_container-2.0.0.tar.gz && \
+    rm /sagemaker_mxnet_container-2.0.0.tar.gz
+
+# "channels first" is recommended for keras-mxnet
+# https://github.com/awslabs/keras-apache-mxnet/blob/master/docs/mxnet_backend/performance_guide.md#channels-first-image-data-format-for-cnn
+RUN mkdir /root/.keras && \
+    echo '{"image_data_format": "channels_first"}' > /root/.keras/keras.json
+
+# This is here to make our installed version of OpenCV work.
+# https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394
+# TODO: Should we be installing OpenCV in our image like this? Is there another way we can fix this?
+RUN ln -s /dev/null /dev/raw1394
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib" \
+    PYTHONIOENCODING=UTF-8 \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+ENV SAGEMAKER_TRAINING_MODULE sagemaker_mxnet_container.training:main

--- a/docker/1.4.0/final/Dockerfile.gpu.training
+++ b/docker/1.4.0/final/Dockerfile.gpu.training
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends software-proper
 # Install pip
 RUN cd /tmp && \
     curl -O https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py 'pip<=18.1' && rm get-pip.py
+    python get-pip.py 'pip==19.1' && rm get-pip.py
 
 WORKDIR /
 


### PR DESCRIPTION
I've removed some of the arguments that existed in the 1.3.0 Dockerfile.

```
docker build -t 520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet-training:1.4-gpu-py3 -f docker/1.4.0/final/Dockerfile.gpu.training --build-arg py_version=3 .
Successfully built 7df913bc3179
Successfully tagged 520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet-training:1.4-gpu-py3

docker build -t 520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet-training:1.4-cpu-py3 -f docker/1.4.0/final/Dockerfile.cpu.training --build-arg py_version=3 .
Successfully built f5ae39c6228d
Successfully tagged 520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet-training:1.4-cpu-py3
```

I've added a few TODOs, as names and such are subject to change for the official release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
