### PR TITLE
add eia dockerfile for 1.4.0

### DIFF
--- a/docker/1.4.0/final/Dockerfile.eia
+++ b/docker/1.4.0/final/Dockerfile.eia
@@ -1,0 +1,41 @@
+ARG py_version
+
+# TODO: the base image name may change
+FROM awsdeeplearningteam/mxnet-model-server:base-cpu-py$py_version
+
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
+
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends \
+    libopencv-dev \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /
+
+# Will install from pypi once packages are released there. For now, copy from local file system.
+# TODO: The name for the tar.gz binary may change
+COPY dist/sagemaker_mxnet_container-2.0.0.tar.gz /sagemaker_mxnet_container-2.0.0.tar.gz
+
+RUN pip install --no-cache /sagemaker_mxnet_container-2.0.0.tar.gz && \
+    \
+    rm /sagemaker_mxnet_container-2.0.0.tar.gz
+
+RUN pip install --no-cache onnx==1.4.1 \
+                           keras-mxnet==2.2.4 \
+                           https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.0-py2.py3-none-manylinux1_x86_64.whl
+
+# This is here to make our installed version of OpenCV work.
+# https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394
+# TODO: Should we be installing OpenCV in our image like this? Is there another way we can fix this?
+RUN ln -s /dev/null /dev/raw1394
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib" \
+    PYTHONIOENCODING=UTF-8 \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+# TODO: The entrypoint may change
+ENTRYPOINT []

--- a/docker/1.4.0/final/Dockerfile.eia
+++ b/docker/1.4.0/final/Dockerfile.eia
@@ -1,6 +1,5 @@
 ARG py_version
 
-# TODO: the base image name may change
 FROM awsdeeplearningteam/mxnet-model-server:base-cpu-py$py_version
 
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
@@ -13,17 +12,14 @@ RUN apt-get update && \
 
 WORKDIR /
 
-# Will install from pypi once packages are released there. For now, copy from local file system.
-# TODO: The name for the tar.gz binary may change
 COPY dist/sagemaker_mxnet_container-2.0.0.tar.gz /sagemaker_mxnet_container-2.0.0.tar.gz
 
-RUN pip install --no-cache /sagemaker_mxnet_container-2.0.0.tar.gz && \
-    \
+RUN pip install --no-cache https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.0-py2.py3-none-manylinux1_x86_64.whl \
+                           keras-mxnet==2.2.4 \
+                           onnx==1.4.1 \
+                           /sagemaker_mxnet_container-2.0.0.tar.gz && \
     rm /sagemaker_mxnet_container-2.0.0.tar.gz
 
-RUN pip install --no-cache onnx==1.4.1 \
-                           keras-mxnet==2.2.4 \
-                           https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.0-py2.py3-none-manylinux1_x86_64.whl
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394
@@ -37,5 +33,4 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
-# TODO: The entrypoint may change
 ENTRYPOINT []

--- a/docker/1.4.0/final/Dockerfile.eia
+++ b/docker/1.4.0/final/Dockerfile.eia
@@ -15,7 +15,7 @@ WORKDIR /
 COPY dist/sagemaker_mxnet_container-2.0.0.tar.gz /sagemaker_mxnet_container-2.0.0.tar.gz
 
 RUN pip install --no-cache https://s3.amazonaws.com/amazonei-apachemxnet/amazonei_mxnet-1.4.0-py2.py3-none-manylinux1_x86_64.whl \
-                           keras-mxnet==2.2.4 \
+                           keras-mxnet==2.2.4.1 \
                            onnx==1.4.1 \
                            /sagemaker_mxnet_container-2.0.0.tar.gz && \
     rm /sagemaker_mxnet_container-2.0.0.tar.gz


### PR DESCRIPTION
The build arg now requires 3.6 and 2.7 instead of the respective 2 and 3. As the base image we build from has that in the name and doing if statement conditionals within the Dockerfile can't fulfill that purpose.

I've removed some of the arguments that existed in the 1.3.0 Dockerfile.

```
docker build -t 520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet-eia:1.4-cpu-py3 -f docker/1.4.0/final/Dockerfile.eia --build-arg py_version=3.6 .
Successfully built 774af2ffa8d6
Successfully tagged 520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet-eia:1.4-cpu-py3
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
