### PR TITLE
Fix mock_open usage

### DIFF
--- a/test/unit/test_training_utils.py
+++ b/test/unit/test_training_utils.py
@@ -30,7 +30,7 @@ def test_save_single_machine(json_dump):
     model = Mock()
     model.data_shapes = []
 
-    with patch('six.moves.builtins.open', mock_open(read_data=Mock())):
+    with patch('six.moves.builtins.open', mock_open()):
         training_utils.save(MODEL_DIR, model)
 
     model.symbol.save.assert_called_with(os.path.join(MODEL_DIR, 'model-symbol.json'))
@@ -43,7 +43,7 @@ def test_save_distributed(json_dump):
     model = Mock()
     model.data_shapes = []
 
-    with patch('six.moves.builtins.open', mock_open(read_data=Mock())):
+    with patch('six.moves.builtins.open', mock_open()):
         training_utils.save(MODEL_DIR, model, current_host=SCHEDULER_HOST,
                             hosts=[SCHEDULER_HOST, WORKER_HOST])
 


### PR DESCRIPTION
*Description of changes:*
The latest version of `mock` changed some behavior, which caused the unit tests to fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
