### PR TITLE
change: parametrize Python version and processor type in integ tests

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -35,9 +35,8 @@ phases:
       # build images
       - python3 scripts/build_all.py --version $FRAMEWORK_FULL_VERSION --account $ACCOUNT --repo $ECR_REPO
 
-      # run cpu integration tests
-      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --py-version 3 --processor cpu --framework-version $FRAMEWORK_FULL_VERSION --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO
-      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --py-version 2 --processor cpu --framework-version $FRAMEWORK_FULL_VERSION --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO
+      # run cpu local integration tests
+      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --processor cpu --py-version 2,3 --framework-version $FRAMEWORK_FULL_VERSION --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO
 
       # push docker images to ECR
       - python3 scripts/publish_all.py --version $FRAMEWORK_FULL_VERSION --account $ACCOUNT --repo $ECR_REPO
@@ -46,20 +45,15 @@ phases:
       - create-key-pair
       - launch-ec2-instance --instance-type $GPU_INSTANCE_TYPE --ami-name dlami-ubuntu
 
-      # run gpu integration tests
+      # run gpu local integration tests
       - printf "$SETUP_CMDS" > $SETUP_FILE
       - ecr_image="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
-      - cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --processor gpu --framework-version $FRAMEWORK_FULL_VERSION --region $AWS_DEFAULT_REGION --docker-base-name $ecr_image"
-      - remote-test --test-cmd "$cmd --py-version 3" --github-repo $GITHUB_REPO --branch master --setup-file $SETUP_FILE
-      - remote-test --test-cmd "$cmd --py-version 2" --github-repo $GITHUB_REPO --branch master --skip-setup
+      - cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --processor gpu --py-version 2,3 --framework-version $FRAMEWORK_FULL_VERSION --region $AWS_DEFAULT_REGION --docker-base-name $ecr_image"
+      - remote-test --test-cmd $cmd --github-repo $GITHUB_REPO --branch master --setup-file $SETUP_FILE
+      - remote-test --test-cmd $cmd --github-repo $GITHUB_REPO --branch master --skip-setup
 
-      # run cpu sagemaker tests
-      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker -n 4 --py-version 3 --processor cpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_FULL_VERSION
-      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker -n 4 --py-version 2 --processor cpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_FULL_VERSION
-
-      # run gpu sagemaker tests
-      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker -n 4 --py-version 3 --processor gpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_FULL_VERSION
-      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker -n 4 --py-version 2 --processor gpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_FULL_VERSION
+      # run sagemaker integration tests
+      - IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker -n 4 --py-version 2,3 --processor cpu,gpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_FULL_VERSION
 
       # write deployment details to file
       - |
@@ -79,10 +73,7 @@ phases:
             "dest": ["'$FRAMEWORK_FULL_VERSION'-gpu-py3", "'$FRAMEWORK_SHORT_VERSION'-gpu-py3", "'$FRAMEWORK_FULL_VERSION'-gpu-py3-'${CODEBUILD_BUILD_ID#*:}'"]
           }],
           "test": [
-            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_training.py --py-version 3 --processor cpu --instance-count 1 --region {region} --docker-base-name '$ECR_REPO' --aws-id 520713654638 --framework-version '$FRAMEWORK_FULL_VERSION'",
-            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_training.py --py-version 3 --processor gpu --instance-count 1 --region {region} --docker-base-name '$ECR_REPO' --aws-id 520713654638 --framework-version '$FRAMEWORK_FULL_VERSION'",
-            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_training.py --py-version 2 --processor cpu --instance-count 1 --region {region} --docker-base-name '$ECR_REPO' --aws-id 520713654638 --framework-version '$FRAMEWORK_FULL_VERSION'",
-            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_training.py --py-version 2 --processor gpu --instance-count 1 --region {region} --docker-base-name '$ECR_REPO' --aws-id 520713654638 --framework-version '$FRAMEWORK_FULL_VERSION'"
+            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_training.py --py-version 2,3 --processor cpu,gpu --instance-count 1 --region {region} --docker-base-name '$ECR_REPO' --aws-id 520713654638 --framework-version '$FRAMEWORK_FULL_VERSION'",
           ]
         }]' > deployments.json
 


### PR DESCRIPTION
*Description of changes:*
follows https://github.com/aws/sagemaker-tensorflow-container/pull/208. I looked through the PR buildspec but didn't see an obvious way to incorporate it without just refactoring large parts of it, so I've left that out of this PR.

```
$ pytest test/integration/ --collect-only
======== test session starts ========
[...]
collected 8 items                                                                                                                                                                                                                                                                                                                                                        
<Module test/integration/local/test_keras_training.py>
  <Function test_keras_training[py3-cpu]>
<Module test/integration/local/test_linear_regression.py>
  <Function test_linear_regression[py3-cpu]>
<Module test/integration/local/test_mnist_training.py>
  <Function test_single_machine[py3-cpu]>
  <Function test_distributed[py3-cpu]>
<Module test/integration/local/test_onnx.py>
  <Function test_onnx_export[py3-cpu]>
<Module test/integration/sagemaker/test_training.py>
  <Function test_training[1-py3-cpu]>
<Module test/integration/sagemaker/test_tuning.py>
  <Function test_tuning[py3-cpu]>
<Module test/integration/sagemaker/test_training.py>
  <Function test_training[2-py3-cpu]>

======== no tests ran in 0.06 seconds ========

$ pytest test/integration/ --processor cpu,gpu --py-version 2,3 --collect-only
======== test session starts ========
[...]
collected 32 items                                                                                                                                                                                                                                                                                                                                                       
<Module test/integration/local/test_keras_training.py>
  <Function test_keras_training[py2-cpu]>
<Module test/integration/local/test_linear_regression.py>
  <Function test_linear_regression[py2-cpu]>
<Module test/integration/local/test_mnist_training.py>
  <Function test_single_machine[py2-cpu]>
  <Function test_distributed[py2-cpu]>
<Module test/integration/local/test_onnx.py>
  <Function test_onnx_export[py2-cpu]>
<Module test/integration/sagemaker/test_training.py>
  <Function test_training[1-py2-cpu]>
<Module test/integration/sagemaker/test_tuning.py>
  <Function test_tuning[py2-cpu]>
<Module test/integration/local/test_keras_training.py>
  <Function test_keras_training[py2-gpu]>
<Module test/integration/local/test_linear_regression.py>
  <Function test_linear_regression[py2-gpu]>
<Module test/integration/local/test_mnist_training.py>
  <Function test_single_machine[py2-gpu]>
  <Function test_distributed[py2-gpu]>
<Module test/integration/local/test_onnx.py>
  <Function test_onnx_export[py2-gpu]>
<Module test/integration/sagemaker/test_training.py>
  <Function test_training[1-py2-gpu]>
<Module test/integration/sagemaker/test_tuning.py>
  <Function test_tuning[py2-gpu]>
<Module test/integration/local/test_keras_training.py>
  <Function test_keras_training[py3-cpu]>
<Module test/integration/local/test_linear_regression.py>
  <Function test_linear_regression[py3-cpu]>
<Module test/integration/local/test_mnist_training.py>
  <Function test_single_machine[py3-cpu]>
  <Function test_distributed[py3-cpu]>
<Module test/integration/local/test_onnx.py>
  <Function test_onnx_export[py3-cpu]>
<Module test/integration/sagemaker/test_training.py>
  <Function test_training[1-py3-cpu]>
<Module test/integration/sagemaker/test_tuning.py>
  <Function test_tuning[py3-cpu]>
<Module test/integration/local/test_keras_training.py>
  <Function test_keras_training[py3-gpu]>
<Module test/integration/local/test_linear_regression.py>
  <Function test_linear_regression[py3-gpu]>
<Module test/integration/local/test_mnist_training.py>
  <Function test_single_machine[py3-gpu]>
  <Function test_distributed[py3-gpu]>
<Module test/integration/local/test_onnx.py>
  <Function test_onnx_export[py3-gpu]>
<Module test/integration/sagemaker/test_training.py>
  <Function test_training[1-py3-gpu]>
<Module test/integration/sagemaker/test_tuning.py>
  <Function test_tuning[py3-gpu]>
<Module test/integration/sagemaker/test_training.py>
  <Function test_training[2-py2-cpu]>
  <Function test_training[2-py2-gpu]>
  <Function test_training[2-py3-cpu]>
  <Function test_training[2-py3-gpu]>

======== no tests ran in 0.07 seconds ========

$ pytest test/integration/sagemaker/test_training.py --processor cpu,gpu --py-version 2,3 --collect-only
======== test session starts ========
[...]
collected 8 items                                                                                                                                                                                                                                                                                                                                                        
<Module test/integration/sagemaker/test_training.py>
  <Function test_training[1-py2-cpu]>
  <Function test_training[1-py2-gpu]>
  <Function test_training[1-py3-cpu]>
  <Function test_training[1-py3-gpu]>
  <Function test_training[2-py2-cpu]>
  <Function test_training[2-py2-gpu]>
  <Function test_training[2-py3-cpu]>
  <Function test_training[2-py3-gpu]>

======== no tests ran in 0.02 seconds ========

$ pytest test/integration/sagemaker/test_training.py --tag foo --collect-only
======== test session starts ========
[...]
collected 2 items                                                                                                                                                                                                                                                                                                                                                        
<Module test/integration/sagemaker/test_training.py>
  <Function test_training[1-py3-cpu]>
  <Function test_training[2-py3-cpu]>

======== no tests ran in 0.01 seconds ========
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
