### PR TITLE
change: explicitly set lower bound for botocore version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,6 @@ setup(
     install_requires=['sagemaker-containers>=2.2.5', 'retrying==1.3.3'],
     extras_require={
         'test': ['tox', 'pluggy==0.11', 'flake8', 'pytest==4.5.0', 'pytest-cov', 'pytest-xdist',
-                 'mock', 'sagemaker', 'docker-compose']
+                 'mock', 'sagemaker', 'docker-compose', 'botocore>=1.12.140']
     },
 )


### PR DESCRIPTION
The recently-adding hyperparameter tuning test (#95) exposed some issue with our dependency chain not having an updated version of botocore.

Similar: https://github.com/aws/sagemaker-tensorflow-container/pull/187

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
