### PR TITLE
fix: remove JSON syntax error from buildspec-release.yml

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -72,7 +72,7 @@ phases:
             "dest": ["'$FRAMEWORK_FULL_VERSION'-gpu-py3", "'$FRAMEWORK_SHORT_VERSION'-gpu-py3", "'$FRAMEWORK_FULL_VERSION'-gpu-py3-'${CODEBUILD_BUILD_ID#*:}'"]
           }],
           "test": [
-            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_training.py --py-version 2,3 --processor cpu,gpu --instance-count 1 --region {region} --docker-base-name '$ECR_REPO' --aws-id 520713654638 --framework-version '$FRAMEWORK_FULL_VERSION'",
+            "IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker/test_training.py --py-version 2,3 --processor cpu,gpu --instance-count 1 --region {region} --docker-base-name '$ECR_REPO' --aws-id 520713654638 --framework-version '$FRAMEWORK_FULL_VERSION'"
           ]
         }]' > deployments.json
 


### PR DESCRIPTION
*Description of changes:*
the release builds are failing with the error "invalid loads value" on deployments.json ([example CodeBuild job](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/projects/sagemaker-mxnet-container-deploy/build/sagemaker-mxnet-container-deploy:c7920a25-f192-4704-9c36-566a3f3d84c3/log?region=us-west-2))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
