### PR TITLE
change: fix build directory in scripts/build_all.py

### DIFF
--- a/scripts/build_all.py
+++ b/scripts/build_all.py
@@ -86,4 +86,4 @@ for arch in ['cpu', 'gpu']:
         prev_image_uri = '{}.dkr.ecr.{}.amazonaws.com/{}'.format(args.account, args.region, dest)
 
         build_dir = os.path.join(root_build_dir, 'py{}'.format(py_version))
-        _build_image(root_build_dir, arch, prev_image_uri, py_version)
+        _build_image(build_dir, arch, prev_image_uri, py_version)


### PR DESCRIPTION
*Description of changes:*
Forgot to change this as part of the 1.4.1 upgrade. Tested in my personal account as much as I could (basically up until the local GPU tests, which don't work in our sandboxed builds at the moment).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
