### PR TITLE
update: Constrain package versions in 1.6.0 dockerfiles

### DIFF
--- a/docker/1.6.0/py2/Dockerfile.cpu
+++ b/docker/1.6.0/py2/Dockerfile.cpu
@@ -45,6 +45,9 @@ COPY sagemaker_mxnet_container.tar.gz /sagemaker_mxnet_container.tar.gz
 RUN pip install --no-cache --upgrade \
     keras-mxnet==2.2.4.2 \
     h5py==2.10.0 \
+    # setuptools<45.0.0 because support for py2 stops with 45.0.0
+    # https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v4500
+    "setuptools<45.0.0" \
     onnx==1.6.0 \
     numpy==1.16.5 \
     pandas==0.24.2 \

--- a/docker/1.6.0/py2/Dockerfile.gpu
+++ b/docker/1.6.0/py2/Dockerfile.gpu
@@ -56,6 +56,9 @@ RUN pip install --no-cache-dir --upgrade \
     h5py==2.10.0 \
     keras-mxnet==2.2.4.2 \
     numpy==1.16.5 \
+    # setuptools<45.0.0 because support for py2 stops with 45.0.0
+    # https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v4500
+    "setuptools<45.0.0" \
     onnx==1.6.0 \
     pandas==0.24.2 \
     Pillow==6.2.0 \

--- a/docker/1.6.0/py3/Dockerfile.cpu
+++ b/docker/1.6.0/py3/Dockerfile.cpu
@@ -77,7 +77,7 @@ RUN ${PIP} install --no-cache --upgrade \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     dgl==0.4.1 \
-    scipy==1.3.1 \
+    scipy==1.2.2 \
     urllib3==1.24 \
     python-dateutil==2.8.0 \
     tqdm==4.39.0 \

--- a/docker/1.6.0/py3/Dockerfile.gpu
+++ b/docker/1.6.0/py3/Dockerfile.gpu
@@ -92,7 +92,7 @@ RUN ${PIP} install --no-cache --upgrade \
     Pillow==6.2.0 \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
-    scipy==1.3.1 \
+    scipy==1.2.2 \
     dgl-cu101==0.4.1 \
     urllib3==1.24 \
     python-dateutil==2.8.0 \


### PR DESCRIPTION
*Description of changes:*
* Constrain setuptools version in py2 dockerfiles
* Pin scipy version to 1.2.2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
