### PR TITLE
Downgrade pip version and unpin awscli

### DIFF
--- a/docker/1.6.0/py2/Dockerfile.cpu
+++ b/docker/1.6.0/py2/Dockerfile.cpu
@@ -32,8 +32,10 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* \
  && ln -s $(which python) /usr/local/bin/python
 
+# MXNet requires pip 19.3.1 due to being backwards compatible
+# with python2
 RUN pip --no-cache-dir install --upgrade \
-    pip \
+    pip==19.3.1 \
     setuptools
 
 WORKDIR /

--- a/docker/1.6.0/py2/Dockerfile.gpu
+++ b/docker/1.6.0/py2/Dockerfile.gpu
@@ -42,8 +42,10 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* \
  && ln -s $(which python) /usr/local/bin/python
 
+# MXNet requires pip 19.3.1 due to being backwards compatible
+# with python2
 RUN pip --no-cache-dir install --upgrade \
-    pip \
+    pip==19.3.1 \
     setuptools
 
 WORKDIR /

--- a/docker/1.6.0/py3/Dockerfile.cpu
+++ b/docker/1.6.0/py3/Dockerfile.cpu
@@ -89,7 +89,7 @@ RUN ${PIP} install --no-cache --upgrade \
     PyYAML==5.1.2 \
     /sagemaker_mxnet_container.tar.gz \
     ${MX_URL} \
-    awscli==1.17.1 \
+    awscli \
  && rm /sagemaker_mxnet_container.tar.gz
 
 # "channels first" is recommended for keras-mxnet

--- a/docker/1.6.0/py3/Dockerfile.cpu
+++ b/docker/1.6.0/py3/Dockerfile.cpu
@@ -56,8 +56,11 @@ RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSIO
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
+
+# MXNet requires pip 19.3.1 due to being backwards compatible
+# with python2
 RUN ${PIP} --no-cache-dir install --upgrade \
-    pip \
+    pip==19.3.1 \
     setuptools
 
 WORKDIR /

--- a/docker/1.6.0/py3/Dockerfile.gpu
+++ b/docker/1.6.0/py3/Dockerfile.gpu
@@ -72,8 +72,11 @@ RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSIO
  && ln -s /usr/local/bin/pip3 /usr/bin/pip \
  && ln -s $(which ${PYTHON}) /usr/local/bin/python
 
+
+# MXNet requires pip 19.3.1 due to being backwards compatible
+# with python2
 RUN ${PIP} --no-cache-dir install --upgrade \
-    pip \
+    pip==19.3.1 \
     setuptools
 
 WORKDIR /

--- a/docker/1.6.0/py3/Dockerfile.gpu
+++ b/docker/1.6.0/py3/Dockerfile.gpu
@@ -105,7 +105,7 @@ RUN ${PIP} install --no-cache --upgrade \
     PyYAML==5.1.2 \
     /sagemaker_mxnet_container.tar.gz \
     ${MX_URL} \
-    awscli==1.17.1 \
+    awscli \
  && rm /sagemaker_mxnet_container.tar.gz
 
 # "channels first" is recommended for keras-mxnet


### PR DESCRIPTION
*Issue #, if available:*
The aws-mxnet pip wheels hosted at [aws-mxnet-pypi/1.6.0](https://aws-mxnet-pypi.s3-us-west-2.amazonaws.com/1.6.0) cannot be installed using pip version 20.0.1

Error message:

```
root@db8864b0db13:/# pip install https://aws-mxnet-pypi.s3-us-west-2.amazonaws.com/1.6.0/aws_mxnet_cu101mkl-1.6.0rc0-py2.py3-none-manylinux1_x86_64.whl
ERROR: aws_mxnet_cu101mkl-1.6.0rc0-py2.py3-none-manylinux1_x86_64.whl is not a supported wheel on this platform.
```

*Description of changes:*
This issues requires the pip version to be downgraded and pinned to 19.3.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
