### PR TITLE
Misspelling of sagemaker_mxnet_container_*.tar.gz

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Example commands for building images:
     # All build instructions assume you're starting from the root directory of this repository
 
     # MXNet 1.6.0, Python 3, CPU
-    $ cp dist/sagemaker-mxnet-container-*.tar.gz docker/1.6.0/.
+    $ cp dist/* docker/1.6.0/.
     $ cp -r docker/artifacts/* docker/1.6.0/py3
     $ cd docker/1.6.0/py3
     $ docker build -t preprod-mxnet:1.6.0-cpu-py3 -f Dockerfile.cpu .

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Example commands for building images:
     # All build instructions assume you're starting from the root directory of this repository
 
     # MXNet 1.6.0, Python 3, CPU
-    $ cp dist/* docker/1.6.0/.
+    $ cp dist/sagemaker_mxnet_container*.tar.gz docker/1.6.0/sagemaker_mxnet_container.tar.gz
     $ cp -r docker/artifacts/* docker/1.6.0/py3
     $ cd docker/1.6.0/py3
     $ docker build -t preprod-mxnet:1.6.0-cpu-py3 -f Dockerfile.cpu .


### PR DESCRIPTION
*Issue #, if available:*
The README file has the following command to setup the sagemaker-mxnet-container repository:

```
cp dist/sagemaker-mxnet-container-*.tar.gz docker/1.6.0/.
```

The name of the tar file should be sagemaker_mxnet_container*.tar.gz and should be copied to the location docker/1.6.0/sagemaker_mxnet_container.tar.gz

*Description of changes:*
This PR makes a documentation change to fix the error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
