### PR TITLE
fix: remove call to deprecated function download_and_install

### DIFF
--- a/src/sagemaker_mxnet_container/training.py
+++ b/src/sagemaker_mxnet_container/training.py
@@ -74,7 +74,7 @@ def train(env):
         _run_mxnet_process('server', env.hosts, ps_port, ps_verbose)
         os.environ.update(_env_vars_for_role('worker', env.hosts, ps_port, ps_verbose))
 
-    framework.modules.download_and_install(env.module_dir)
+    framework.modules.import_module(env.module_dir)
     framework.entry_point.run(env.module_dir,
                               env.user_entry_point,
                               env.to_cmd_args(),

--- a/src/sagemaker_mxnet_container/training.py
+++ b/src/sagemaker_mxnet_container/training.py
@@ -74,7 +74,6 @@ def train(env):
         _run_mxnet_process('server', env.hosts, ps_port, ps_verbose)
         os.environ.update(_env_vars_for_role('worker', env.hosts, ps_port, ps_verbose))
 
-    framework.modules.download_and_install(env.module_dir)
     framework.entry_point.run(env.module_dir,
                               env.user_entry_point,
                               env.to_cmd_args(),

--- a/src/sagemaker_mxnet_container/training.py
+++ b/src/sagemaker_mxnet_container/training.py
@@ -74,6 +74,7 @@ def train(env):
         _run_mxnet_process('server', env.hosts, ps_port, ps_verbose)
         os.environ.update(_env_vars_for_role('worker', env.hosts, ps_port, ps_verbose))
 
+    framework.modules.download_and_install(env.module_dir)
     framework.entry_point.run(env.module_dir,
                               env.user_entry_point,
                               env.to_cmd_args(),

--- a/test/unit/test_training.py
+++ b/test/unit/test_training.py
@@ -71,9 +71,8 @@ def distributed_training_env():
 @patch('subprocess.Popen')
 @patch('sagemaker_mxnet_container.training._host_lookup')
 @patch('sagemaker_mxnet_container.training._verify_hosts')
-@patch('sagemaker_containers.beta.framework.modules.download_and_install')
 @patch('sagemaker_containers.beta.framework.entry_point.run')
-def test_train_for_distributed_scheduler(run_entry_point, download_and_install, verify_hosts,
+def test_train_for_distributed_scheduler(run_entry_point, verify_hosts,
                                          host_lookup, popen, distributed_training_env):
     host_lookup.return_value = IP_ADDRESS
 
@@ -93,7 +92,6 @@ def test_train_for_distributed_scheduler(run_entry_point, download_and_install, 
 
     popen.assert_has_calls(calls)
 
-    download_and_install.assert_called_with(MODULE_DIR)
     run_entry_point.assert_called_with(MODULE_DIR,
                                        MODULE_NAME,
                                        distributed_training_env.to_cmd_args(),
@@ -105,9 +103,8 @@ def test_train_for_distributed_scheduler(run_entry_point, download_and_install, 
 @patch('subprocess.Popen')
 @patch('sagemaker_mxnet_container.training._host_lookup')
 @patch('sagemaker_mxnet_container.training._verify_hosts')
-@patch('sagemaker_containers.beta.framework.modules.download_and_install')
 @patch('sagemaker_containers.beta.framework.entry_point.run')
-def test_train_for_distributed_worker(run_entry_point, download_and_install, verify_hosts,
+def test_train_for_distributed_worker(run_entry_point, verify_hosts,
                                       host_lookup, popen, distributed_training_env):
     host_lookup.return_value = IP_ADDRESS
 
@@ -121,7 +118,6 @@ def test_train_for_distributed_worker(run_entry_point, download_and_install, ver
 
     popen.assert_called_once_with(MXNET_COMMAND, shell=True, env=server_env)
 
-    download_and_install.assert_called_with(MODULE_DIR)
     run_entry_point.assert_called_with(MODULE_DIR,
                                        MODULE_NAME,
                                        distributed_training_env.to_cmd_args(),
@@ -129,12 +125,10 @@ def test_train_for_distributed_worker(run_entry_point, download_and_install, ver
                                        runner=framework.runner.ProcessRunnerType)
 
 
-@patch('sagemaker_containers.beta.framework.modules.download_and_install')
 @patch('sagemaker_containers.beta.framework.entry_point.run')
-def test_train_for_single_machine(run_entry_point, download_and_install,
+def test_train_for_single_machine(run_entry_point,
                                   single_machine_training_env):
     training.train(single_machine_training_env)
-    download_and_install.assert_called_with(MODULE_DIR)
     run_entry_point.assert_called_with(MODULE_DIR,
                                        MODULE_NAME,
                                        single_machine_training_env.to_cmd_args(),

--- a/test/unit/test_training.py
+++ b/test/unit/test_training.py
@@ -71,8 +71,9 @@ def distributed_training_env():
 @patch('subprocess.Popen')
 @patch('sagemaker_mxnet_container.training._host_lookup')
 @patch('sagemaker_mxnet_container.training._verify_hosts')
+@patch('sagemaker_containers.beta.framework.modules.download_and_install')
 @patch('sagemaker_containers.beta.framework.entry_point.run')
-def test_train_for_distributed_scheduler(run_entry_point, verify_hosts,
+def test_train_for_distributed_scheduler(run_entry_point, download_and_install, verify_hosts,
                                          host_lookup, popen, distributed_training_env):
     host_lookup.return_value = IP_ADDRESS
 
@@ -92,6 +93,7 @@ def test_train_for_distributed_scheduler(run_entry_point, verify_hosts,
 
     popen.assert_has_calls(calls)
 
+    download_and_install.assert_called_with(MODULE_DIR)
     run_entry_point.assert_called_with(MODULE_DIR,
                                        MODULE_NAME,
                                        distributed_training_env.to_cmd_args(),
@@ -103,8 +105,9 @@ def test_train_for_distributed_scheduler(run_entry_point, verify_hosts,
 @patch('subprocess.Popen')
 @patch('sagemaker_mxnet_container.training._host_lookup')
 @patch('sagemaker_mxnet_container.training._verify_hosts')
+@patch('sagemaker_containers.beta.framework.modules.download_and_install')
 @patch('sagemaker_containers.beta.framework.entry_point.run')
-def test_train_for_distributed_worker(run_entry_point, verify_hosts,
+def test_train_for_distributed_worker(run_entry_point, download_and_install, verify_hosts,
                                       host_lookup, popen, distributed_training_env):
     host_lookup.return_value = IP_ADDRESS
 
@@ -118,6 +121,7 @@ def test_train_for_distributed_worker(run_entry_point, verify_hosts,
 
     popen.assert_called_once_with(MXNET_COMMAND, shell=True, env=server_env)
 
+    download_and_install.assert_called_with(MODULE_DIR)
     run_entry_point.assert_called_with(MODULE_DIR,
                                        MODULE_NAME,
                                        distributed_training_env.to_cmd_args(),
@@ -125,10 +129,12 @@ def test_train_for_distributed_worker(run_entry_point, verify_hosts,
                                        runner=framework.runner.ProcessRunnerType)
 
 
+@patch('sagemaker_containers.beta.framework.modules.download_and_install')
 @patch('sagemaker_containers.beta.framework.entry_point.run')
-def test_train_for_single_machine(run_entry_point,
+def test_train_for_single_machine(run_entry_point, download_and_install,
                                   single_machine_training_env):
     training.train(single_machine_training_env)
+    download_and_install.assert_called_with(MODULE_DIR)
     run_entry_point.assert_called_with(MODULE_DIR,
                                        MODULE_NAME,
                                        single_machine_training_env.to_cmd_args(),

--- a/test/unit/test_training.py
+++ b/test/unit/test_training.py
@@ -71,9 +71,9 @@ def distributed_training_env():
 @patch('subprocess.Popen')
 @patch('sagemaker_mxnet_container.training._host_lookup')
 @patch('sagemaker_mxnet_container.training._verify_hosts')
-@patch('sagemaker_containers.beta.framework.modules.download_and_install')
+@patch('sagemaker_containers.beta.framework.modules.import_module')
 @patch('sagemaker_containers.beta.framework.entry_point.run')
-def test_train_for_distributed_scheduler(run_entry_point, download_and_install, verify_hosts,
+def test_train_for_distributed_scheduler(run_entry_point, import_module, verify_hosts,
                                          host_lookup, popen, distributed_training_env):
     host_lookup.return_value = IP_ADDRESS
 
@@ -93,7 +93,7 @@ def test_train_for_distributed_scheduler(run_entry_point, download_and_install, 
 
     popen.assert_has_calls(calls)
 
-    download_and_install.assert_called_with(MODULE_DIR)
+    import_module.assert_called_with(MODULE_DIR)
     run_entry_point.assert_called_with(MODULE_DIR,
                                        MODULE_NAME,
                                        distributed_training_env.to_cmd_args(),
@@ -105,9 +105,9 @@ def test_train_for_distributed_scheduler(run_entry_point, download_and_install, 
 @patch('subprocess.Popen')
 @patch('sagemaker_mxnet_container.training._host_lookup')
 @patch('sagemaker_mxnet_container.training._verify_hosts')
-@patch('sagemaker_containers.beta.framework.modules.download_and_install')
+@patch('sagemaker_containers.beta.framework.modules.import_module')
 @patch('sagemaker_containers.beta.framework.entry_point.run')
-def test_train_for_distributed_worker(run_entry_point, download_and_install, verify_hosts,
+def test_train_for_distributed_worker(run_entry_point, import_module, verify_hosts,
                                       host_lookup, popen, distributed_training_env):
     host_lookup.return_value = IP_ADDRESS
 
@@ -121,7 +121,7 @@ def test_train_for_distributed_worker(run_entry_point, download_and_install, ver
 
     popen.assert_called_once_with(MXNET_COMMAND, shell=True, env=server_env)
 
-    download_and_install.assert_called_with(MODULE_DIR)
+    import_module.assert_called_with(MODULE_DIR)
     run_entry_point.assert_called_with(MODULE_DIR,
                                        MODULE_NAME,
                                        distributed_training_env.to_cmd_args(),
@@ -129,12 +129,12 @@ def test_train_for_distributed_worker(run_entry_point, download_and_install, ver
                                        runner=framework.runner.ProcessRunnerType)
 
 
-@patch('sagemaker_containers.beta.framework.modules.download_and_install')
+@patch('sagemaker_containers.beta.framework.modules.import_module')
 @patch('sagemaker_containers.beta.framework.entry_point.run')
-def test_train_for_single_machine(run_entry_point, download_and_install,
+def test_train_for_single_machine(run_entry_point, import_module,
                                   single_machine_training_env):
     training.train(single_machine_training_env)
-    download_and_install.assert_called_with(MODULE_DIR)
+    import_module.assert_called_with(MODULE_DIR)
     run_entry_point.assert_called_with(MODULE_DIR,
                                        MODULE_NAME,
                                        single_machine_training_env.to_cmd_args(),


### PR DESCRIPTION
*Description of changes:*
- The `sagemaker-containers` function `modules.download_and_install()` is deprecated and breaks network isolation.
- The function `modules.import_module()` contains the necessary functionality to download, extract, and import the module without breaking network isolation. It also supports `requirements.txt`. `modules.download_and_install()` has been replaced with `modules.import_module()` accordingly.
- The function `entry_point.run()` (which is called on the following line) contains some overlapping functionality with `modules.import_module()`, but it also runs the entry point. Upcoming work to refactor [sagemaker-containers](https://github.com/aws/sagemaker-containers/) will remove redundant functionality and deprecated code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
