### PR TITLE
Use GluonNLP stable release tag

### DIFF
--- a/docker/1.6.0/py3/Dockerfile.cpu
+++ b/docker/1.6.0/py3/Dockerfile.cpu
@@ -78,7 +78,7 @@ RUN ${PIP} install --no-cache --upgrade \
     scikit-learn==0.20.4 \
     dgl==0.4.1 \
     scipy==1.2.2 \
-    git+git://github.com/dmlc/gluon-nlp.git@f19ace982075ea009af81f5e9f687cc2276f50ea \
+    git+git://github.com/dmlc/gluon-nlp.git@v0.9.0 \
     urllib3==1.24 \
     python-dateutil==2.8.0 \
     tqdm==4.39.0 \

--- a/docker/1.6.0/py3/Dockerfile.gpu
+++ b/docker/1.6.0/py3/Dockerfile.gpu
@@ -94,7 +94,7 @@ RUN ${PIP} install --no-cache --upgrade \
     scikit-learn==0.20.4 \
     scipy==1.2.2 \
     dgl-cu101==0.4.1 \
-    git+git://github.com/dmlc/gluon-nlp.git@f19ace982075ea009af81f5e9f687cc2276f50ea \
+    git+git://github.com/dmlc/gluon-nlp.git@v0.9.0 \
     urllib3==1.24 \
     python-dateutil==2.8.0 \
     tqdm==4.39.0 \


### PR DESCRIPTION
Use GluonNLP stable release tag.
Previously a pre-release commit was used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
