### PR TITLE
fix: Fix issue in installation of sagemaker-containers

### DIFF
--- a/docker/1.6.0/py2/Dockerfile.cpu
+++ b/docker/1.6.0/py2/Dockerfile.cpu
@@ -74,9 +74,9 @@ WORKDIR /
 RUN pip install --no-cache --upgrade \
     keras-mxnet==2.2.4.2 \
     h5py==2.10.0 \
-    # setuptools<45.0.0 because support for py2 stops with 45.0.0
+    # setuptools<45 because support for py2 stops with 45.0.0
     # https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v4500
-    "setuptools<45.0.0" \
+    "setuptools<45" \
     onnx==1.6.0 \
     numpy==1.16.5 \
     pandas==0.24.2 \
@@ -88,6 +88,9 @@ RUN pip install --no-cache --upgrade \
     python-dateutil==2.8.0 \
     mpi4py==3.0.2 \
     ${MX_URL} \
+    # inotify-simple updated to 1.3.0 and has an issue that prevents the installation
+    # of the enum34 package on py2. inotify-simple is used in sagemaker-mxnet-training
+    "inotify-simple<1.3" \
     sagemaker-mxnet-training==3.1.6
 
 # Install Horovod

--- a/docker/1.6.0/py2/Dockerfile.gpu
+++ b/docker/1.6.0/py2/Dockerfile.gpu
@@ -116,9 +116,9 @@ RUN pip install --no-cache-dir --upgrade \
     h5py==2.10.0 \
     keras-mxnet==2.2.4.2 \
     numpy==1.16.5 \
-    # setuptools<45.0.0 because support for py2 stops with 45.0.0
+    # setuptools<45 because support for py2 stops with 45.0.0
     # https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v4500
-    "setuptools<45.0.0" \
+    "setuptools<45" \
     onnx==1.6.0 \
     pandas==0.24.2 \
     Pillow==6.2.0 \
@@ -129,6 +129,9 @@ RUN pip install --no-cache-dir --upgrade \
     python-dateutil==2.8.0 \
     mpi4py==3.0.2 \
     ${MX_URL} \
+    # inotify-simple updated to 1.3.0 and has an issue that prevents the installation
+    # of the enum34 package on py2. inotify-simple is used in sagemaker-mxnet-training
+    "inotify-simple<1.3" \
     sagemaker_mxnet_training==3.1.6
 
 # Install Horovod, temporarily using CUDA stubs


### PR DESCRIPTION
*Description of changes:*
Fix issue in installation of `sagemaker-containers` by constraining the version of `inotify-simple` being used in py2 dockerfiles to `inotify-simple<1.3`.

The following is the sequence of dependencies that causes this issue:
sagemaker-mxnet-training > sagemaker-containers > gevent > inotify-simple > enum34

Installation of `inotify-simple==1.3.0` results in the following error:
```
Collecting inotify-simple
  Downloading https://files.pythonhosted.org/packages/d5/b9/e8893eb0cf4ea05f091ca833d4129c5cbb193535fd4962fb5bb23c54b79f/inotify_simple-1.3.0.tar.gz
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-myOcJF/inotify-simple/setup.py'"'"'; __file__='"'"'/tmp/pip-install-myOcJF/inotify-simple/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-myOcJF/inotify-simple/pip-egg-info
         cwd: /tmp/pip-install-myOcJF/inotify-simple/
    Complete output (22 lines):
    /usr/local/lib/python2.7/dist-packages/pkg_resources/py2_warn.py:22: UserWarning: Setuptools will stop working on Python 2
    ************************************************************
    You are running Setuptools on Python 2, which is no longer
    supported and
    >>> SETUPTOOLS WILL STOP WORKING <<<
    in a subsequent release (no sooner than 2020-04-20).
    Please ensure you are installing
    Setuptools using pip 9.x or later or pin to `setuptools<45`
    in your environment.
    If you have done those things and are still encountering
    this message, please comment in
    https://github.com/pypa/setuptools/issues/1458
    about the steps that led to this unsupported combination.
    ************************************************************
      sys.version_info < (3,) and warnings.warn(pre + "*" * 60 + msg + "*" * 60)
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-myOcJF/inotify-simple/setup.py", line 3, in <module>
        from inotify_simple import __version__
      File "inotify_simple.py", line 3, in <module>
        from enum import Enum, IntEnum
    ImportError: No module named enum
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
