### PR TITLE
skip test for python2

### DIFF
--- a/test/integration/sagemaker/test_experiments.py
+++ b/test/integration/sagemaker/test_experiments.py
@@ -27,8 +27,11 @@ DATA_PATH = os.path.join(RESOURCE_PATH, "mnist")
 SCRIPT_PATH = os.path.join(DATA_PATH, "mnist_gluon_basic_hook_demo.py")
 
 
-@pytest.mark.skip_py2_containers
-def test_training(sagemaker_session, ecr_image, instance_type, instance_count):
+def test_training(sagemaker_session, ecr_image, instance_type, instance_count, py_version):
+
+    if py_version is None or '2' in py_version:
+        pytest.skip('Skipping python2 {}'.format(py_version))
+        return
 
     from smexperiments.experiment import Experiment
     from smexperiments.trial import Trial


### PR DESCRIPTION
```
=================================== FAILURES ===================================
___________________________ test_training[1-py3-cpu] ___________________________

sagemaker_session = <sagemaker.session.Session object at 0x7fc10750fa10>
ecr_image = '841569659894.dkr.ecr.us-east-1.amazonaws.com/beta-mxnet-training:1.6.0-py3-gpu-with-horovod-build'
instance_type = 'ml.p2.16xlarge', instance_count = 1

    @pytest.mark.skip_py2_containers
    def test_training(sagemaker_session, ecr_image, instance_type, instance_count):
    
>       from smexperiments.experiment import Experiment
E       ImportError: No module named smexperiments.experiment

test/integration/sagemaker/test_experiments.py:33: ImportError
___________________________ test_training[2-py3-cpu] ___________________________

sagemaker_session = <sagemaker.session.Session object at 0x7fc10750fa10>
ecr_image = '841569659894.dkr.ecr.us-east-1.amazonaws.com/beta-mxnet-training:1.6.0-py3-gpu-with-horovod-build'
instance_type = 'ml.p2.16xlarge', instance_count = 2

    @pytest.mark.skip_py2_containers
    def test_training(sagemaker_session, ecr_image, instance_type, instance_count):
    
>       from smexperiments.experiment import Experiment
E       ImportError: No module named smexperiments.experiment

test/integration/sagemaker/test_experiments.py:33: ImportError
=============================== warnings summary ===============================
/usr/local/lib/python2.7/dist-packages/_pytest/mark/structures.py:324
  /usr/local/lib/python2.7/dist-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.skip_py2_containers - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/usr/local/lib/python2.7/dist-packages/_pytest/mark/structures.py:324
  /usr/local/lib/python2.7/dist-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.skip_test_in_region - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============== 2 failed, 7 passed, 2 warnings in 3354.72 seconds ===============
```