### PR TITLE
fix: upgrade sagemaker-containers to 2.8.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
 
     # We don't declare our dependency on mxnet here because we build with
     # different packages for different variants (e.g. mxnet-mkl and mxnet-cu90).
-    install_requires=['sagemaker-containers>=2.4.10.post0', 'retrying==1.3.3'],
+    install_requires=['sagemaker-containers>=2.8.2', 'retrying==1.3.3'],
     extras_require={
         'test': test_dependencies
     },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
sagemaker-containers==2.8.2 contains https://github.com/aws/sagemaker-containers/pull/261, which has a fix for requirements.txt support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
