### PR TITLE
change: use sagemaker_mxnet_training<4 in Dockerfiles instead of pinning the version

### DIFF
--- a/docker/1.6.0/py2/Dockerfile.cpu
+++ b/docker/1.6.0/py2/Dockerfile.cpu
@@ -91,7 +91,7 @@ RUN pip install --no-cache --upgrade \
     # inotify-simple updated to 1.3.0 and has an issue that prevents the installation
     # of the enum34 package on py2. inotify-simple is used in sagemaker-mxnet-training
     "inotify-simple<1.3" \
-    sagemaker-mxnet-training==3.1.6
+    "sagemaker-mxnet-training<4"
 
 # Install Horovod
 RUN pip install --no-cache-dir horovod==0.19.0

--- a/docker/1.6.0/py2/Dockerfile.gpu
+++ b/docker/1.6.0/py2/Dockerfile.gpu
@@ -132,7 +132,7 @@ RUN pip install --no-cache-dir --upgrade \
     # inotify-simple updated to 1.3.0 and has an issue that prevents the installation
     # of the enum34 package on py2. inotify-simple is used in sagemaker-mxnet-training
     "inotify-simple<1.3" \
-    sagemaker_mxnet_training==3.1.6
+    "sagemaker-mxnet-training<4"
 
 # Install Horovod, temporarily using CUDA stubs
 RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs \

--- a/docker/1.6.0/py3/Dockerfile.cpu
+++ b/docker/1.6.0/py3/Dockerfile.cpu
@@ -114,7 +114,7 @@ RUN ${PIP} install --no-cache --upgrade \
     sagemaker-experiments==0.1.7 \
     PyYAML==5.1.2 \
     mpi4py==3.0.2 \
-    sagemaker_mxnet_training==3.1.6 \
+    "sagemaker-mxnet-training<4" \
     ${MX_URL} \
     sagemaker==1.50.17 \
     awscli

--- a/docker/1.6.0/py3/Dockerfile.gpu
+++ b/docker/1.6.0/py3/Dockerfile.gpu
@@ -155,7 +155,7 @@ RUN ${PIP} install --no-cache --upgrade \
     sagemaker-experiments==0.1.7 \
     PyYAML==5.1.2 \
     mpi4py==3.0.2 \
-    sagemaker_mxnet_training==3.1.6 \
+    "sagemaker-mxnet-training<4" \
     ${MX_URL} \
     sagemaker==1.50.17 \
     awscli


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This matches the other framework's Dockerfiles where the version is an upper bound rather than a specific version. Also, this should pick up the changes with aws/sagemaker-containers#261 (via #159)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
