### PR TITLE
upgrade pillow etc. to fix safety issues in 1.6.0 dockerfiles

### DIFF
--- a/docker/1.6.0/py2/Dockerfile.cpu
+++ b/docker/1.6.0/py2/Dockerfile.cpu
@@ -80,11 +80,11 @@ RUN pip install --no-cache --upgrade \
     onnx==1.6.0 \
     numpy==1.16.5 \
     pandas==0.24.2 \
-    Pillow==6.2.0 \
+    Pillow==6.2.2 \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     scipy==1.2.2 \
-    urllib3==1.24 \
+    urllib3==1.25.8 \
     python-dateutil==2.8.0 \
     mpi4py==3.0.2 \
     ${MX_URL} \

--- a/docker/1.6.0/py2/Dockerfile.gpu
+++ b/docker/1.6.0/py2/Dockerfile.gpu
@@ -121,11 +121,11 @@ RUN pip install --no-cache-dir --upgrade \
     "setuptools<45" \
     onnx==1.6.0 \
     pandas==0.24.2 \
-    Pillow==6.2.0 \
+    Pillow==6.2.2 \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     scipy==1.2.2 \
-    urllib3==1.24 \
+    urllib3==1.25.8 \
     python-dateutil==2.8.0 \
     mpi4py==3.0.2 \
     ${MX_URL} \

--- a/docker/1.6.0/py3/Dockerfile.cpu
+++ b/docker/1.6.0/py3/Dockerfile.cpu
@@ -93,7 +93,6 @@ RUN ${PIP} --no-cache-dir install --upgrade \
 
 WORKDIR /
 
-# install PyYAML==5.1.2 to avoid conflict with latest awscli
 # python-dateutil==2.8.0 to satisfy botocore associated with latest awscli
 RUN ${PIP} install --no-cache --upgrade \
     keras-mxnet==2.2.4.2 \
@@ -101,19 +100,19 @@ RUN ${PIP} install --no-cache --upgrade \
     onnx==1.6.0 \
     numpy==1.17.2 \
     pandas==0.25.1 \
-    Pillow==6.2.0 \
+    Pillow==7.1.0 \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     dgl==0.4.1 \
     scipy==1.2.2 \
     gluonnlp==0.9.1 \
     gluoncv==0.6.0 \
-    urllib3==1.24 \
+    urllib3==1.25.8 \
     python-dateutil==2.8.0 \
     tqdm==4.39.0 \
     smdebug==0.7.1 \
     sagemaker-experiments==0.1.7 \
-    PyYAML==5.1.2 \
+    PyYAML==5.3.1 \
     mpi4py==3.0.2 \
     "sagemaker-mxnet-training<4" \
     ${MX_URL} \

--- a/docker/1.6.0/py3/Dockerfile.gpu
+++ b/docker/1.6.0/py3/Dockerfile.gpu
@@ -134,7 +134,6 @@ RUN ${PIP} --no-cache-dir install --upgrade \
 
 WORKDIR /
 
-# install PyYAML==5.1.2 to avoid conflict with latest awscli
 # python-dateutil==2.8.0 to satisfy botocore associated with latest awscli
 RUN ${PIP} install --no-cache --upgrade \
     keras-mxnet==2.2.4.2 \
@@ -142,19 +141,19 @@ RUN ${PIP} install --no-cache --upgrade \
     numpy==1.17.2 \
     onnx==1.6.0 \
     pandas==0.25.1 \
-    Pillow==6.2.0 \
+    Pillow==7.1.0 \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     scipy==1.2.2 \
     dgl-cu101==0.4.1 \
     gluonnlp==0.9.1 \
     gluoncv==0.6.0 \
-    urllib3==1.24 \
+    urllib3==1.25.8 \
     python-dateutil==2.8.0 \
     tqdm==4.39.0 \
     smdebug==0.7.1 \
     sagemaker-experiments==0.1.7 \
-    PyYAML==5.1.2 \
+    PyYAML==5.3.1 \
     mpi4py==3.0.2 \
     "sagemaker-mxnet-training<4" \
     ${MX_URL} \


### PR DESCRIPTION
*Issue #, if available:*
Safety issue
```
-> pillow, installed 6.2.0, affected <6.2.2, id 37782
libImaging/FliDecode.c in Pillow before 6.2.2 has an FLI buffer overflow. See: CVE-2020-5313.
--
-> pillow, installed 6.2.0, affected <6.2.2, id 37781
libImaging/PcxDecode.c in Pillow before 6.2.2 has a PCX P mode buffer overflow. See:CVE-2020-5312.
--
-> pillow, installed 6.2.0, affected <6.2.2, id 37780
libImaging/SgiRleDecode.c in Pillow before 6.2.2 has an SGI buffer overflow. See: CVE-2020-5311.
--
-> pillow, installed 6.2.0, affected <6.2.2, id 37779
libImaging/TiffDecode.c in Pillow before 6.2.2 has a TIFF decoding integer overflow, related to realloc. See: CVE-2020-5310.
--
-> pillow, installed 6.2.0, affected >6.0,<6.2.2, id 37772
There is a DoS vulnerability in Pillow before 6.2.2 caused by FpxImagePlugin.py calling the range function on an unvalidated 32-bit integer if the number of bands is large. On Windows running 32-bit Python, this results in an OverflowError or MemoryError due to the 2 GB limit. However, on Linux running 64-bit Python this results in the process being terminated by the OOM killer. See: CVE-2019-19911.
```
*Description of changes:*
Upgrade Pillow to latest version for py2 and py3 correspondingly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
