### PR TITLE
feature: add Python 3.7 support

### DIFF
--- a/.coveragerc_py37
+++ b/.coveragerc_py37
@@ -1,0 +1,20 @@
+[run]
+branch = True
+timid = True
+
+[report]
+exclude_lines =
+    pragma: no cover
+    pragma: py3 no cover
+    if six.PY2
+    elif six.PY2
+
+partial_branches =
+    pragma: no cover
+    pragma: py3 no cover
+    if six.PY3
+    elif six.PY3
+
+show_missing = True
+
+fail_under = 90

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -12,7 +12,7 @@ phases:
       # run unit tests
       - AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= AWS_SESSION_TOKEN=
         AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=
-        tox -e py27,py36 -- test/unit
+        tox -e py27,py36,py37 --parallel all -- test/unit
 
       # run local integ tests
       #- $(aws ecr get-login --no-include-email --region us-west-2)

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -12,7 +12,7 @@ phases:
       # run unit tests
       - AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= AWS_SESSION_TOKEN=
         AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=
-        tox -e py27,py36,py37 -- test/unit
+        tox -e py27,py36,py37 --parallel all -- test/unit
 
       # run local integ tests
       #- $(aws ecr get-login --no-include-email --region us-west-2)

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -12,7 +12,7 @@ phases:
       # run unit tests
       - AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= AWS_SESSION_TOKEN=
         AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=
-        tox -e py27,py36,py37 --parallel all -- test/unit
+        tox -e py27,py36,py37 -- test/unit
 
       # run local integ tests
       #- $(aws ecr get-login --no-include-email --region us-west-2)

--- a/buildspec-toolkit.yml
+++ b/buildspec-toolkit.yml
@@ -30,7 +30,7 @@ phases:
       - tox -e flake8,twine
 
       # run unit tests
-      - tox -e py36,py27 test-toolkit/unit
+      - tox -e py27,py36,py37 --parallel all -- test/unit
 
       # define tags
       - GENERIC_CPU_TAG="$FRAMEWORK_VERSION-mxnet-cpu-$BUILD_ID"

--- a/buildspec-toolkit.yml
+++ b/buildspec-toolkit.yml
@@ -30,7 +30,7 @@ phases:
       - tox -e flake8,twine
 
       # run unit tests
-      - tox -e py27,py36,py37 -- test/unit
+      - tox -e py27,py36,py37 --parallel all -- test/unit
 
       # define tags
       - GENERIC_CPU_TAG="$FRAMEWORK_VERSION-mxnet-cpu-$BUILD_ID"

--- a/buildspec-toolkit.yml
+++ b/buildspec-toolkit.yml
@@ -30,7 +30,7 @@ phases:
       - tox -e flake8,twine
 
       # run unit tests
-      - tox -e py27,py36,py37 --parallel all -- test/unit
+      - tox -e py27,py36,py37 -- test/unit
 
       # define tags
       - GENERIC_CPU_TAG="$FRAMEWORK_VERSION-mxnet-cpu-$BUILD_ID"

--- a/setup.py
+++ b/setup.py
@@ -60,12 +60,13 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 
     # We don't declare our dependency on mxnet here because we build with
     # different packages for different variants (e.g. mxnet-mkl and mxnet-cu90).
-    install_requires=['sagemaker-training>=3.4.2', 'retrying==1.3.3'],
+    install_requires=['sagemaker-training>=3.5.0', 'retrying==1.3.3'],
     extras_require={
         'test': test_dependencies
     },

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 [tox]
-envlist = py27,py36,flake8,twine
+envlist = py27,py36,py37,flake8,twine
 skip_missing_interpreters = False
 
 [travis]


### PR DESCRIPTION
*Description of changes:*
- Upgrade version of sagemaker_training to `3.5.0`, which supports Python 3.7.
- Update tox and buildspecs to test against py37.
- Update Python version in `setup.py`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
