### PR TITLE
fix: Bump version of sagemaker-training for typing fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
 
     # We don't declare our dependency on mxnet here because we build with
     # different packages for different variants (e.g. mxnet-mkl and mxnet-cu90).
-    install_requires=['sagemaker-training>=3.5.0', 'retrying==1.3.3'],
+    install_requires=['sagemaker-training>=3.5.1', 'retrying==1.3.3'],
     extras_require={
         'test': test_dependencies
     },


### PR DESCRIPTION
*Description of changes:*
This consumes the change from this PR: https://github.com/aws/sagemaker-training-toolkit/pull/61


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
